### PR TITLE
feat(admin): on-behalf editing with audit log + admin UX surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,100 @@
+# Pack 218 — Agent conventions
+
+This file captures conventions any agent (human or otherwise) should follow when
+working in this repository. Read before editing.
+
+## Audit log convention (load-bearing)
+
+Every persistent write to a model that inherits `SQLModelWithSave` (`User`,
+`Family`, `Event`, `EventRegistration`) **must** go through
+`SQLModelWithSave.save()` or `SQLModelWithSave.delete_by_id()`. Both methods
+write one row to `ActionLog` in the same transaction, attributing the change
+to the request's current actor with an optional reason.
+
+Raw `session.add(instance)` followed by `session.commit()` **bypasses the
+audit log** and is disallowed in production code without an explicit
+`# audit: bypassed because <reason>` comment on the line. The audit log is
+the only record of who did what; bypasses leave permanent gaps.
+
+When the actor is acting on behalf of another user (the request's current
+actor differs from the row's subject — see `pack218.audit.is_self_edit` for
+the exact rule, which counts same-family edits as self-edits), the save path
+requires a non-empty `current_reason` and rejects writes to blocklisted
+fields (`email`, `username`, `hashed_password`, `is_admin`, `can_login`,
+`email_confirmed`, `email_confirmation_code`) and admin-on-admin edits
+(both User records and EventRegistrations whose owner is an admin).
+
+**Exemption (the only one):** `ActionLog` itself is the universal-write-path
+recursion bypass. Its `save()` skips enforcement and self-recording (otherwise
+recording would recurse forever), and `delete_by_id()` raises — audit rows are
+append-only. The bypass is annotated in `pack218/entities/__init__.py` with an
+`audit:` comment. Do not add other exemptions without changing this contract.
+
+**Test code is exempt** from the bypass-comment rule. Test fixtures and DB
+setup helpers commonly need to seed rows directly via `session.add` /
+`session.commit` to construct preconditions; the in-memory SQLite fixture has
+no request context and no audit-log requirement. The rule above applies to
+production paths only.
+
+## Querying the audit log
+
+The parent-visible "Changes made on my behalf" panel is the canonical read
+pattern. See `pack218/pages/on_behalf_panel.py::_fetch_rows` for the
+reference query, which:
+
+1. Filters by `subject_user_id == current_user.id` OR
+   `(entity_name == 'Family' AND entity_id == current_user.family_id)` —
+   the latter surfaces Family-scoped writes to every family member without
+   per-write fan-out.
+2. Excludes `actor_user_id == current_user.id` to hide self-edits from the
+   parent's view.
+3. Orders by `created_at DESC`, capped to last 20 rows.
+
+For agent-driven reads (e.g., "show me everything Cubmaster Dave did last
+week"), filter by `actor_user_id` and `created_at`. The `(actor_user_id)`
+and `(subject_user_id, created_at)` indexes cover both shapes.
+
+`ActionLog.field_changes` is a JSON object. For updates: `{field: [before,
+after]}`. For deletes: `{"_action": "delete", "snapshot": {column: value, ...}}`.
+For creates: `{field: [None, value]}` per column. Sensitive User columns
+(`hashed_password`, `email_confirmation_code`, `email`) are stored as
+`"<redacted>"` instead of the raw value — the audit log records that they
+changed without retaining the values themselves.
+
+## Request actor / reason context
+
+`pack218.audit.current_actor` and `pack218.audit.current_reason` are
+`contextvars` set by the request boundary in `pack218.app.chrome()`. Page
+handlers and UI components do not need to read them directly. To temporarily
+set a reason before a save (e.g., from a "reason" modal), use the standard
+pattern:
+
+```python
+from pack218.audit import AuditError, current_reason
+
+token = current_reason.set(reason_text)
+try:
+    instance.save(session=session)
+except AuditError as e:
+    ui.notify(str(e), color='negative')
+finally:
+    current_reason.reset(token)
+```
+
+The `finally` block is mandatory — without it, the reason can leak into
+later saves in the same Python execution context (especially in tests and
+scripts where there is no request boundary to scope the contextvar).
+
+## Test data
+
+Tests that touch the DB use the `db_session` fixture in `tests/conftest.py`
+(in-memory SQLite, fresh per test). Tests that exercise on-behalf rules
+should also use the `isolated_audit_context` fixture (also in
+`tests/conftest.py`) to keep `current_actor` / `current_reason` from leaking
+between tests.
+
+## Origin documents
+
+- Plan: `docs/plans/2026-05-11-001-feat-admin-on-behalf-and-audit-log-plan.md`
+- Brainstorm: `docs/brainstorms/2026-05-11-admin-on-behalf-requirements.md`
+- Ideation: `docs/ideation/2026-05-11-admin-impersonation-ideation.md`

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Simple website for CubScout Pack 218
 ## Local setup
 
 ```shell
+./copy_db_from_prod.sh # Optional (and need to be provided by the user, no checked in)
 ./local_dev_setup.sh   # copies DB from prod, creates venv, syncs dependencies
 ./local_dev_run.sh     # starts the dev server on 0.0.0.0:8001
 ```

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -17,7 +17,7 @@ if config.config_file_name is not None:
 
 # add your model's MetaData object here
 # for 'autogenerate' support
-from pack218.entities.models import Event, Family, User
+from pack218.entities.models import Event, Family, User, EventRegistration, ActionLog
 
 target_metadata = SQLModel.metadata
 

--- a/alembic/versions/34b4263e0ba3_add_action_log.py
+++ b/alembic/versions/34b4263e0ba3_add_action_log.py
@@ -1,0 +1,51 @@
+"""add action log
+
+Revision ID: 34b4263e0ba3
+Revises: efdb27d61ada
+Create Date: 2026-05-11 12:38:28.000026
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+# https://arunanshub.hashnode.dev/using-sqlmodel-with-alembic
+import sqlmodel.sql.sqltypes
+
+
+# revision identifiers, used by Alembic.
+revision: str = '34b4263e0ba3'
+down_revision: Union[str, None] = 'efdb27d61ada'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'action_log',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('actor_user_id', sa.Integer(), nullable=True),
+        sa.Column('subject_user_id', sa.Integer(), nullable=True),
+        sa.Column('entity_name', sa.String(), nullable=False),
+        sa.Column('entity_id', sa.Integer(), nullable=False),
+        sa.Column('action', sa.String(), nullable=False),
+        sa.Column('field_changes', sa.JSON(), nullable=False),
+        sa.Column('reason', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['actor_user_id'], ['user.id'], name=op.f('fk_action_log_actor_user_id_user')),
+        sa.ForeignKeyConstraint(['subject_user_id'], ['user.id'], name=op.f('fk_action_log_subject_user_id_user')),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_action_log')),
+    )
+    with op.batch_alter_table('action_log', schema=None) as batch_op:
+        batch_op.create_index(batch_op.f('ix_action_log_actor_user_id'), ['actor_user_id'], unique=False)
+        batch_op.create_index('ix_action_log_entity', ['entity_name', 'entity_id'], unique=False)
+        batch_op.create_index('ix_action_log_subject_created', ['subject_user_id', 'created_at'], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('action_log', schema=None) as batch_op:
+        batch_op.drop_index('ix_action_log_subject_created')
+        batch_op.drop_index('ix_action_log_entity')
+        batch_op.drop_index(batch_op.f('ix_action_log_actor_user_id'))
+
+    op.drop_table('action_log')

--- a/alembic/versions/9ed788ef938a_add_cancelled_to_event.py
+++ b/alembic/versions/9ed788ef938a_add_cancelled_to_event.py
@@ -1,0 +1,35 @@
+"""add cancelled to event
+
+Revision ID: 9ed788ef938a
+Revises: 34b4263e0ba3
+Create Date: 2026-05-19 22:09:35.460319
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+# https://arunanshub.hashnode.dev/using-sqlmodel-with-alembic
+import sqlmodel.sql.sqltypes
+
+
+# revision identifiers, used by Alembic.
+revision: str = '9ed788ef938a'
+down_revision: Union[str, None] = '34b4263e0ba3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add ``cancelled`` as NOT NULL with a server-side default of false so that
+    # existing rows get a deterministic value at column-create time. Without a
+    # server_default, the ALTER would fail on a table with existing rows.
+    with op.batch_alter_table('event', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('cancelled', sa.Boolean(), nullable=False, server_default=sa.false())
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('event', schema=None) as batch_op:
+        batch_op.drop_column('cancelled')

--- a/docs/brainstorms/2026-05-11-admin-on-behalf-requirements.md
+++ b/docs/brainstorms/2026-05-11-admin-on-behalf-requirements.md
@@ -1,0 +1,163 @@
+---
+date: 2026-05-11
+topic: admin-on-behalf
+---
+
+# Admin "On-Behalf-Of" Edits + Universal Action Log
+
+## Summary
+
+Add a primitive that lets an admin update another user's `EventRegistration` or profile basics on their behalf — without session-swap impersonation — while a new `ActionLog` table captures every model write with `actor`, `subject`, before/after values, timestamp, and (when `actor ≠ subject`) a required reason. The same log powers a parent-visible panel showing changes made on the parent's behalf, shipping in the same PR.
+
+---
+
+## Problem Frame
+
+Pack 218's admins (the Cubmaster and a small number of committee members) regularly need to update a parent's record on their behalf: dropping a kid from a camping trip the day before, switching a meal selection from a text message, fixing a phone number after a parent calls. Today the only ways to do this are (1) admin CRUD pages that let an admin edit any user or family record but record no actor information — the change shows up as if the parent did it themselves — or (2) direct SQLite edits for `EventRegistration`, which is not in the admin CRUD UI. Both paths produce silent, unattributed mutations. There is no audit trail of any kind (`pack218/entities/__init__.py:14`), so if a change is disputed ("I didn't pick vegetarian"), there is no way to know who, when, or why. The first time a kid arrives at camp expecting one meal and gets another because of a misheard phone call, the volunteer-trust culture that the app relies on takes a real hit.
+
+---
+
+## Actors
+
+- A1. **Admin**: a `User.is_admin = True` user (Cubmaster, committee member). Acts in their own session at all times — never session-swaps to another user.
+- A2. **Parent (subject)**: a `User.is_admin = False` user whose `EventRegistration` or profile is being modified by the admin on their behalf. Sees the changes on their own view of the affected records.
+- A3. **System**: the `SQLModelWithSave.save()` hook that records every write to `ActionLog`, plus the read path that surfaces on-behalf-of changes to the parent.
+
+---
+
+## Key Flows
+
+- F1. **Admin edits an EventRegistration on behalf of a parent**
+  - **Trigger:** A1 is looking at an event roster and sees a row for A2 that needs a change (e.g., "Sarah called, dropping Saturday breakfast").
+  - **Actors:** A1, A2 (passive), A3.
+  - **Steps:**
+    1. A1 navigates to the event's admin roster view, clicks an edit affordance on A2's row.
+    2. A form opens pre-loaded with A2's current EventRegistration values.
+    3. A1 changes the relevant fields.
+    4. Because `actor (A1.id) ≠ subject (A2.id)`, the save prompts for a required reason ("Sarah texted at 7pm").
+    5. On submit, the record is updated AND a row is inserted into `ActionLog` with both ids, the diff, the timestamp, and the reason.
+  - **Outcome:** A2's registration reflects the change; A2's profile/event-registration view now shows a parent-visible entry: "On-behalf-of: Cubmaster Dave changed your Saturday breakfast on May 11 (reason: 'Sarah texted at 7pm')."
+  - **Covered by:** R1, R2, R3, R5, R7, R9.
+
+- F2. **Admin edits a User profile basic on behalf of a parent**
+  - **Trigger:** A1 is in the existing `/admin/users` NiceCRUD page and updates A2's phone number, allergies, or food prefs.
+  - **Actors:** A1, A2 (passive), A3.
+  - **Steps:**
+    1. A1 opens A2's row in the existing admin user CRUD.
+    2. A1 edits a permitted field.
+    3. On save, the reason prompt fires (because `actor ≠ subject`).
+    4. The save and the `ActionLog` insert happen atomically.
+  - **Outcome:** Same as F1, surfaced on A2's profile page.
+  - **Covered by:** R1, R2, R4, R5, R7, R9.
+
+- F3. **Parent views on-behalf-of changes**
+  - **Trigger:** A2 logs in and visits their profile or any of their event-registration views.
+  - **Actors:** A2, A3.
+  - **Steps:**
+    1. The page queries `ActionLog` for rows where `subject_id = A2.id AND actor_id ≠ A2.id`, scoped to the entity being viewed (profile or this event's registration).
+    2. A panel renders the recent entries with admin name, date, fields changed, and reason.
+  - **Outcome:** A2 can see every change made on their behalf without consulting an admin.
+  - **Covered by:** R8, R9.
+
+- F4. **Admin attempts a blocked-field edit**
+  - **Trigger:** A1 tries to change A2's email, username, password, `is_admin`, `can_login`, or `email_confirmed` flag from any admin flow.
+  - **Actors:** A1, A3.
+  - **Steps:**
+    1. The form either hides the field or rejects the save with a clear message ("This field can only be changed by the user themselves").
+    2. No `ActionLog` row is written for the blocked write.
+  - **Outcome:** Blocked fields remain authoritative to the parent.
+  - **Covered by:** R6.
+
+---
+
+## Requirements
+
+**Action log substrate**
+- R1. Introduce a new append-only `ActionLog` table with: `id`, `actor_user_id`, `subject_user_id`, `entity_name`, `entity_id`, `action` (create / update / delete), `field_changes` (JSON of `{field: [before, after]}`), `created_at` timestamp, and `reason` (nullable text).
+- R2. Every save through `SQLModelWithSave.save()` (and therefore every save through `NiceCRUDWithSQL.create` / `.update`) inserts exactly one corresponding `ActionLog` row before the surrounding transaction commits. Self-edits (`actor == subject`) are also logged, with `reason = NULL`; they exist so the substrate is uniform and so future general activity views are possible — they are not shown in the parent-visible panel.
+
+**On-behalf-of editing primitive**
+- R3. Admins can edit any other user's `EventRegistration` from a new admin entry point on the event roster. The form is pre-populated with the current values and writes back through the same `EventRegistration.save()` path used today.
+- R4. Admins can edit a permitted set of fields on any other user's `User` profile through the existing `/admin/users` admin CRUD page: `first_name`, `last_name`, `phone_number`, `family_member_type`, `has_food_allergies`, `food_allergies_detail`, `has_food_intolerances`, `food_intolerances`.
+- R5. When `actor_user_id ≠ subject_user_id` for any write, the UI prompts for a required free-text reason before the save commits. An empty reason rejects the save with an inline validation error.
+- R6. The following User fields are blocklisted from on-behalf-of edits regardless of admin status: `email`, `username`, `hashed_password`, `is_admin`, `can_login`, `email_confirmed`, `email_confirmation_code`. The blocklist is enforced both in the UI (fields disabled or hidden when admin is editing someone else's record) and in the save path (rejection if a blocked field appears in the diff with `actor ≠ subject`).
+- R7. Admins cannot use the on-behalf-of flow against another admin's record (`subject_user_id` resolves to a user where `is_admin = True`). The entry point is hidden and the save path rejects such attempts.
+
+**Parent-visible transparency**
+- R8. On every page where a parent views their own profile or one of their own `EventRegistration`s, a panel lists `ActionLog` entries where `subject_user_id = current_user.id` and `actor_user_id ≠ current_user.id`, scoped to the entity in view. Each entry shows the admin's display name, the date, a human-readable description of fields changed, and the reason.
+- R9. The parent-visible panel ships in the same pull request as R1–R7. It is not a follow-up.
+
+**Migration and surface area**
+- R10. One new Alembic migration adds the `action_log` table. No changes to existing tables are required.
+- R11. The reason-prompt mechanism is shared between the new EventRegistration admin entry point (R3) and the existing `/admin/users` and `/admin/families` NiceCRUD admin pages. Implementations may differ in form (modal vs inline) but the validation rule is one rule.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R2, R5.** Given Cubmaster Dave is signed in and updates Sarah Chen's `EventRegistration` for the Spring Camporee to set `eat_saturday_breakfast = False`, when he submits the form without a reason, the save is rejected with "Reason is required when editing another user's record"; when he types "Sarah texted, dropping breakfast" and submits, the registration is updated and one `ActionLog` row is written with `actor=Dave, subject=Sarah, entity=EventRegistration, field_changes={eat_saturday_breakfast: [True, False]}, reason="Sarah texted, dropping breakfast"`.
+- AE2. **Covers R2.** Given Sarah Chen is signed in and updates her own `food_intolerances` on her profile, when she saves, the update succeeds without a reason prompt and one `ActionLog` row is written with `actor=Sarah, subject=Sarah, reason=NULL`.
+- AE3. **Covers R6.** Given an admin opens Sarah Chen's row in `/admin/users`, when the admin tries to change `Sarah.email` or `Sarah.is_admin`, the fields are disabled (or hidden) and any attempt to submit a payload that includes them is rejected with "These fields can only be changed by the user themselves"; no `ActionLog` row is written.
+- AE4. **Covers R7.** Given there are two admins, Dave and Lisa, when Dave attempts to open the on-behalf-of edit affordance for Lisa's EventRegistration, the affordance is not visible; if he constructs the request directly it is rejected with "On-behalf-of edits cannot target another admin's record."
+- AE5. **Covers R8.** Given Sarah Chen's `EventRegistration` was edited yesterday by Cubmaster Dave with reason "Phone call 7pm", when Sarah next visits that event's registration page, she sees a panel reading "Cubmaster Dave changed your Saturday breakfast and overnight on May 10 (reason: 'Phone call 7pm')."
+
+---
+
+## Success Criteria
+
+- A Cubmaster handling a Friday-night last-minute change for a parent who can't log in can complete the action — including typing the reason — in well under a minute, without leaving the existing admin UI mental model.
+- After this ships, every mutation in the application carries a verifiable answer to "who did this and when?", including normal self-edits.
+- A parent visiting the app the next day after an admin-on-behalf edit can see what was changed, by whom, and why, on the same page where the affected data lives — without asking an admin.
+- The data model gives the next adjacent feature (co-parent invite, magic-link self-service, standing proxy, password reset audit, future role tables) the audit substrate it needs without further schema changes.
+
+---
+
+## Scope Boundaries
+
+- **No session-swap / impersonation mode.** Admins never act under another user's session. The grounding work explicitly rejected this and the design here makes it structurally impossible to forget which identity is acting.
+- **No bulk operations.** One-at-a-time edits only. CSV import and bulk waitlist promotion are real future features but out of scope here; when they ship, they will use the same `ActionLog` substrate with the importing admin as `actor` and the affected user as `subject`.
+- **No "view as parent" read-only debugging affordance.** Useful but a different feature; separate brainstorm.
+- **No side-effect suppression decorator.** The MVP's blocklist and the fact that we are not touching email/login fields means no surprise emails are triggered by an on-behalf-of edit. Revisit when the first non-email side-effect (Stripe receipt, waitlist promotion email, SMS reminder) is added; a `suppress_when_on_behalf` decorator should land at the same time.
+- **No multi-admin race protection.** At single-admin reality today, last-write-wins is acceptable. Revisit if a second admin joins and concurrent-edit incidents emerge.
+- **No reason picklist or category curation.** Free text only. Categorization, reporting, or analytics over reasons are out of scope.
+- **No backfill of historical writes into `ActionLog`.** The log starts empty at migration time and accumulates from the first write forward. Pre-existing data is not retroactively attributed.
+- **No co-parent invite, no magic-link self-service, no `Delegation` standing proxy.** Each is a complement, not a blocker — tracked separately in the ideation document (ideas S4, S5, S7).
+- **No standalone "Phone Intake" page.** The admin entry points reuse the existing event roster view and the existing `/admin/users` and `/admin/families` CRUD pages. A standalone phone-intake screen is a future polish if it earns its keep.
+
+---
+
+## Key Decisions
+
+- **Scoped-action over session swap.** Admin stays signed in as themselves throughout. The five independent ideation frames that converged on this were reinforced by the documented failure modes of session swap (Facebook 2018 "View As" side-effect leak, Salesforce/Varonis undetectable admin actions, Pigment "forgot I was impersonating" class of bugs). At pack scale this is also the cheapest path.
+- **Hook the audit log at `SQLModelWithSave.save()`, not at the per-page or per-route layer.** The base class is the only universal write path (`pack218/entities/__init__.py:20`); `NiceCRUDWithSQL.update` and `.create` both call `item.save()` (`pack218/entities/__init__.py:101-118`). One hook captures everything; per-page hooks would miss any future write path.
+- **`field_changes` stored as a JSON column, not a normalized per-field row.** Pack scale (<50 families, dozens of writes/month) makes the simpler shape strictly better; querying for "what changed" is a `JSON_EXTRACT` away if it ever matters.
+- **Required free-text reason, no picklist.** Picklist curation has nonzero ongoing cost and the volunteer reasons are inherently messy ("Sarah texted at 7pm because the kid is sick"). Free text captures intent in the user's own words. If reporting needs categories later, we can mine the text or add a picklist then.
+- **Block-list approach to dangerous fields, not allow-list per record type.** Block-list is explicit and short; new fields default to editable unless flagged. An allow-list would require adding every new safe field forever.
+- **Self-edits also produce `ActionLog` rows (with `reason = NULL`).** Costs nothing extra at this scale and gives us a uniform substrate for general activity log views in the future. The parent-visible panel filters them out.
+- **Admin-on-admin blocked.** Matches the universal industry pattern (ZITADEL, RFC 8693 nuances, Salesforce). No legitimate use case in a volunteer pack.
+- **Parent-visible panel ships in the same PR.** Trust signal must land at the same moment as the new admin power.
+
+---
+
+## Dependencies / Assumptions
+
+- The existing `SQLModelWithSave.save()` flow at `pack218/entities/__init__.py:14-33` is the universal write path; verified during the brainstorm. `NiceCRUDWithSQL.update` and `.create` both delegate to it. Any future code that bypasses this base class (e.g., a raw SQLAlchemy session.add followed by commit) will silently bypass the audit log and is therefore disallowed by convention. A short note in `AGENTS.md` (or `CLAUDE.md`) capturing this convention is a small cost worth paying as part of this PR.
+- `User.email` is the login identity (`User.get_current` resolves the session via email lookup at `pack218/entities/models.py:402-406`). This is why `email` is in the blocklist alongside `hashed_password`/`username`. A future "let admin update a parent's email" feature would need an explicit email-verification flow and is out of scope.
+- Alembic is the migration tool of record (`alembic/versions/`); one new migration adds the table.
+- Admin identity in the session is via `User.get_current(request)` → `request.session["user"]["email"]` → DB lookup. The action log records `actor_user_id` from `User.get_current()` at save time; no new session machinery needed.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+(None — all product decisions resolved during brainstorm.)
+
+### Deferred to Planning
+
+- [Affects R3][Technical] Exact admin entry point for `EventRegistration` editing — most natural place is the existing event detail/roster view, but its current shape and whether to add a per-row inline form vs a modal vs a redirect to a new page is a planning decision.
+- [Affects R5][Technical] Reason prompt UX — modal before save vs inline required field in the form. Both satisfy R5; pick based on what feels native in NiceGUI.
+- [Affects R8][Technical] Parent-visible panel placement — top of profile/registration view, collapsible, last 30 days? Pick what works visually given NiceGUI's components.
+- [Affects R2][Technical] How the actor is resolved inside `SQLModelWithSave.save()` — passing `actor_id` through the call site vs reading it from a request-scoped context. Planning should consider whether `nicegui` or starlette gives a clean way to access the current request from within a model method, and what the test-time injection story looks like.
+- [Affects R2][Needs research] Whether the audit insert should happen in the same transaction as the save (atomic; the log is never out of sync with the data) or a separate one (lower contention; small risk of orphan log rows on failure). At pack scale either is fine; planning should pick and document.

--- a/docs/ideation/2026-05-11-admin-impersonation-ideation.md
+++ b/docs/ideation/2026-05-11-admin-impersonation-ideation.md
@@ -1,0 +1,145 @@
+---
+date: 2026-05-11
+topic: admin-impersonation
+focus: Admin needs to take action on behalf of a parent (e.g., update a camping trip registration when the parent can't make changes themselves)
+mode: repo-grounded
+---
+
+# Ideation: admin "act on behalf of" in pack218
+
+## Grounding Context
+
+### Codebase context
+- **Stack:** Python + NiceGUI (FastAPI + SQLModel + SQLAlchemy + Alembic). SQLite local dev. Google OAuth2 + email-based auth, local dev fallback to hardcoded user.
+- **Layout:** `pack218/app.py` (main routing), `pages/` (UI), `entities/` (models), `persistence/` (DB layer), `email/`, `images/`.
+- **Auth model:** `request.session["user"]` holds Google OAuth user info. Single boolean `User.is_admin`. `assert_is_admin()` is the only authorization gate, called per-page. No middleware enforcement. No JWT — session is mutable.
+- **Key entities:** `User`, `Family` (group container with parents/members), `Event` (camping trips, capacity, waitlisting), `EventRegistration` (signup + meals + overnight).
+- **Audit trail:** ZERO. No `modified_by`, no `action_ts`, no activity log.
+- **Convention:** `SQLModelWithSave` base class with `.save()`, `.get_by_id()`, `.get_all()` helpers — universal write path.
+- **Strategy:** No STRATEGY.md. Hobby/volunteer Cub Scout pack. Recent commits: waitlisting, event capacity. Bias: keep simple, ship value to volunteer admins, avoid enterprise creep.
+
+### External context (prior art, distilled)
+- Production-grade library patterns (django-hijack, devise-masquerade, laravel-impersonate) all share the same shape: store original admin in separate session slot, swap identity, persistent banner, explicit exit.
+- RFC 8693 distinguishes impersonation (only `sub` claim survives — admin disappears) from delegation (`act` claim preserves admin alongside subject). Delegation is the cleaner audit pattern.
+- Pigment (2026): separate JWT with `act` claim + admin identity, 30-min expiry, read-only flag enforced at middleware, build-time static analyzer, dark-border viewport.
+- Healthcare proxy (HIPAA "personal representative"): caregiver gets their OWN credentials linked to patient — acts *on behalf of*, not *as*. Tiered scopes. Consent-first.
+- sudo vs su: `sudo -u <user> <action>` (scoped, action-level) vs `su` (full swap, riskier).
+- Salesforce "Log In As" requires target consent; Varonis breach showed undetectable admin actions when no anomaly monitoring on impersonation.
+- Facebook "View As" (2018): read-only preview loaded a write-capable component that generated a real auth token — 50M accounts. Any "act as" mode must explicitly suppress side-effects.
+- PowerSchool admin-creates-parent-account: data-entry-on-behalf pattern, lower-risk than impersonation when user hasn't onboarded.
+- Authress position: prefer narrow scoped grants over impersonation — "admin updated X for parent" is more honest than "parent X updated their record."
+- Universal audit schema: `actor_id`, `subject_id`, `action`, `timestamp`, optional `reason`.
+
+### Past learnings
+None — `docs/solutions/` does not yet exist. Greenfield from learnings standpoint.
+
+## Ranked Ideas
+
+### 1. Phone Intake form — admin acts as themselves, scoped sudo-action, reason required
+**Description:** Admin stays signed in as themselves and opens a single page that picks a subject family + event (or profile section). The form pre-fills with the subject's current values; admin edits and submits. Server writes the change with `actor_id = admin, subject_id = parent` plus a one-line reason ("Sarah called, dropping Friday overnight"). No session swap; no banner-and-forget; no "I'm Sarah right now" cognitive trap. Names the feature honestly for the actual workflow (capturing a phone/text request) rather than the mechanism (impersonation).
+**Warrant:** `direct:` `SQLModelWithSave.save()` is the universal write path and `assert_is_admin()` is the only auth gate — adding one form + one write hook is a small delta. `external:` sudo `-u` (scoped action) > `su` (full swap); Authress's "narrow scoped grants over impersonation"; PowerSchool data-entry-on-behalf.
+**Rationale:** Solves the canonical Friday-night-10pm case in one click without inheriting any of the impersonation failure modes catalogued in the grounding (Facebook 2018 side-effects, Pigment forgot-I-was-in-it, Salesforce/Varonis undetectable admin actions, GDPR right-to-know failures).
+**Downsides:** Cannot debug "what does Sarah see when she logs in?" — needs a separate read-only view (worth its own brainstorm). Multi-admin concurrent edits still race (single-admin reality today; revisit later).
+**Confidence:** 85%
+**Complexity:** Low
+**Status:** Explored
+
+### 2. Universal `ActionLog(actor, subject, entity, before, after, ts, reason)` hooked into `SQLModelWithSave.save()`
+**Description:** One append-only table, one save-hook. Today actor and subject are identical for every write; once #1 ships they diverge. Schema unchanged between the two states. Indexable by `subject_id` (parent asks "what changed on my account?") and `actor_id` (volunteer asks "what did I do last Saturday?").
+**Warrant:** `direct:` Grounding flagged "Audit trail: ZERO. No `modified_by`, no `action_ts`, no activity log" and named `SQLModelWithSave.save()` as the universal write path. `external:` audit schema is universal across django-hijack, devise-masquerade, Pigment, RFC 8693 (`act` claim), AWS CloudTrail.
+**Rationale:** Highest-leverage move in the set. Every future feature that mutates data gets free auditability — waitlist promotions, capacity overrides, the roadmap'd password-reset emails, GDPR/parental-disclosure requests, debugging "why did this registration disappear?" Impersonation just becomes the special case where `actor ≠ subject`. Pays off whether or not #1 ever ships.
+**Downsides:** Adds rows on every write — negligible at pack scale (<50 families). Requires a small read path for the parent-visible view in #3.
+**Confidence:** 90%
+**Complexity:** Low
+**Status:** Explored
+
+### 3. Parent-visible "changes made on my behalf" panel
+**Description:** On the parent's own profile and registration pages, show a small panel listing recent changes made by anyone other than themselves: *"Apr 14 — Cubmaster Dave changed your Saturday breakfast to vegetarian (reason: 'text from Sarah')."* Drawn directly from #2. Optionally email a digest after every admin-on-behalf write.
+**Warrant:** `external:` Real-estate buyer's-agent law — *fiduciary visibility runs toward the principal*; the principal sees the agent's name on every document. Inverts the common engineering pattern of hiding the actor from the subject. Aligns with the volunteer-trust culture of a pack and forecloses the Salesforce/Varonis undetectable-admin-action class entirely.
+**Rationale:** Million-eyeball audit at near-zero implementation cost. Parents will immediately notice if a change appears that they didn't request — the social mechanism a volunteer-run pack actually relies on.
+**Downsides:** Slight UI clutter (collapsible, last-N-days). Requires #2.
+**Confidence:** 80%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 4. Co-parent invite — provision the second User on the same Family
+**Description:** The `Family` model already supports multiple parents. Most "parent can't update" cases are not impersonation problems — they are "only one parent in the household ever signed in with Google." Add a one-click "Invite co-parent" button on every family page that sends a Google OAuth invite to the second adult, landing as a regular `User` linked to the same `Family` with equal edit rights.
+**Warrant:** `direct:` Grounding confirms `Family` is the existing group container with parent membership; only the invite UX is missing. Reuses the email primitive already on the roadmap for password reset.
+**Rationale:** Solves the *root cause* of a large fraction of impersonation requests instead of building a workaround. Zero new authorization surface; reuses existing Google OAuth flow.
+**Downsides:** Some households deliberately keep one logged-in account; need an off-ramp. Doesn't help single-parent families or grandparent pickups (#1 and #5 cover those).
+**Confidence:** 80%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 5. Magic-link "Cancel / Update meals / Update overnight" in every event email
+**Description:** Every confirmation and reminder email already gets sent. Append signed magic links — valid until the event starts, scoped to that one registration, single-use — for the most common parent self-service actions. No login required.
+**Warrant:** `direct:` `pack218/email/` and confirmation-email infrastructure already exist; recent commits "Implement Waitlisting" + "Add support for Event capacity" show active work in this area. `reasoned:` The cheapest impersonation is the one no one ever needs.
+**Rationale:** ~80% of the "act on behalf of a parent" cases the user named are last-minute changes a parent could do themselves if the friction were low enough. Magic links route the action through the parent's own identity — clean audit trail by default.
+**Downsides:** Token security needs care (sign, expire, single-use, scoped). Doesn't help when contact info is wrong (loops back to #1).
+**Confidence:** 75%
+**Complexity:** Low-Medium
+**Status:** Unexplored
+
+### 6. Side-effect suppression decorator for `actor ≠ subject` writes
+**Description:** Once any "on behalf of" write path exists (#1, #5 fallback, future CSV import, future bulk waitlist promotion), guard against the Facebook-2018 failure mode: a read-only-looking action that fires real notifications, capacity recalculations, or payment side-effects on the subject's behalf. Add a `@side_effect(suppress_when_on_behalf=True)` decorator on every function in `pack218/email/` and future integrations. Default new side-effects to opt-in-suppression-fail-closed.
+**Warrant:** `external:` Facebook 2018 breach affected 50M accounts because "View As" loaded a write-capable video uploader that generated a real auth token. Grounding: "any 'act as' mode must explicitly suppress side-effects." Pigment's middleware-layer read-only enforcement.
+**Rationale:** Cheap to bake in NOW while there's only the email subsystem to instrument. Expensive to retrofit after the first surprise email goes out.
+**Downsides:** Adds one decorator per side-effecting function. Requires a team convention every new email/notification PR must follow.
+**Confidence:** 70%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 7. Standing proxy — parent declares `Delegation(grantor, grantee, scope, expires_at)`
+**Description:** The other direction of #1: instead of admin claiming authority each time, the parent grants standing permission from their settings ("Allow Cubmaster Dave to manage my family's registrations until May 31"). One small table generalizes admin-on-behalf, grandparent help, divorced-parent shared custody, and future Den-Leader scoped roles. Admin's "act on behalf" menu only lists users who have granted them a proxy.
+**Warrant:** `external:` USPS Form 3575 — the recipient declares forwarding, with start, end, and forwarder identity. HIPAA "personal representative" model. Salesforce's "Log In As" requires target consent. Structural property: *agency originates from the principal.*
+**Rationale:** Lower priority than #1 + #4 because it adds a UX step parents must initiate, but a stronger consent posture if/when the pack grows past one admin. The `Delegation` table is also the right primitive for a future "Den Leader manages only their den" feature.
+**Downsides:** Probably overkill for a single-admin volunteer pack today. Worth schema-defining; UX can wait.
+**Confidence:** 55%
+**Complexity:** Medium
+**Status:** Unexplored
+
+## Cross-Cutting Note
+
+The strongest cross-frame convergence was on **"don't build session-swap impersonation at all."** Five of six frames independently arrived at sudo-action / scoped-write / phone-intake variants rather than the full identity-swap pattern the user's prompt implies. The web research grounding amplified this: every documented breach (Facebook 2018, Salesforce/Varonis) and every modern best-practice writeup (Authress, RFC 8693 delegation > impersonation) points the same direction.
+
+If pack218 genuinely needs the literal session-swap experience (e.g., for debugging "what does Sarah see"), that's a separate, smaller idea worth a standalone brainstorm — most likely as a read-only "view-as" with explicit side-effect suppression (#6 applied) rather than a writable impersonation mode.
+
+## Recommended Starting Pair
+
+**#1 + #2 ship together.** #1 is the user-facing primitive that solves the Friday-night-10pm case. #2 is the audit substrate that makes #1 trustworthy and seeds every future feature. **#3** is the natural follow-up sprint. **#4** and **#5** are independent and can ship in any order to reduce #1's load. **#6** ships alongside #1 as a guard. **#7** is schema-worthy but not build-worthy yet.
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | Annotate every form `self-only` vs `assistable` whitelist | Too much ceremony for <50 families; subsumed by #1 + #6 |
+| 2 | $0 hidden `on_behalf_of_email` form field | Fragile; relies on admin remembering a hidden field; creates two-tier UX |
+| 3 | 10-second chip-grid admin dashboard | Strong UX idea but a refinement of #1, not a separate primitive — fold into #1 brainstorm |
+| 4 | Read-only stand-in view + structured write | Subsumed by #1; standalone read-only view is a separate brainstorm |
+| 5 | Reason field as standalone idea | Subsumed by #2 (ActionLog has `reason` column) |
+| 6 | Reason-required banner for actor≠subject | Subsumed by #1 + #2 (form already collects reason) |
+| 7 | Buyer's-agent disclosure footer (standalone) | Subsumed by #3 (parent-visible panel) |
+| 8 | Notary "with parent present" witness toggle | Folds into #2's `reason` field; not a separate primitive |
+| 9 | Admin-proposes-parent-confirms link | Adds latency to the Friday-night case (parent unreachable); use #5 for cases where parent CAN respond |
+| 10 | Inbound SMS/email parser | Too much infra and security surface for hobby-scale; out of scope |
+| 11 | Proposal queue / expediter tickets | Subsumed by item 9 critique |
+| 12 | Two-key launch (every action awaits parent confirm) | Breaks the canonical use case (parent unreachable); too strict |
+| 13 | Family-scoped delegate tokens | Subsumed by #7 (`Delegation` table) |
+| 14 | Admin as temp "guest parent" on Family | Clever but couples admin assistance to family membership; #1 is cleaner |
+| 15 | Zero-admin peer-rubber-stamp pack | Throws away legitimate convenience of having a Cubmaster; thought-experiment value only |
+| 16 | `get_acting_context()` helper | Premature abstraction; emerges naturally from #1 implementation |
+| 17 | `assert_can(actor, action, subject)` capability service | YAGNI at single-admin scale; revisit if multiple roles emerge |
+| 18 | `EventCoordinator` / `DenLeader` scoped role tables | Premature for one admin; meeting-test fails at current scale |
+| 19 | `Event.coordinator_user_id` ownership | Useful direction if multi-admin emerges; not needed now |
+| 20 | Backstage-badge event-scoped + 60min impersonation | Mitigation for session-swap risk; #1 (no session swap) makes it unnecessary |
+| 21 | Sharded admins by den + quorum | Premature for <50 families |
+| 22 | Acting banner + dark viewport border | Vestigial under #1 (no session-swap mode to flag) |
+| 23 | ATC handoff call-and-response | Only relevant under session-swap; #1 has no handoff |
+| 24 | Substitute-teacher role intersection | Only relevant under session-swap; #1 sidesteps |
+| 25 | Three tiers (View / Suggest / Act as) | Worth a brainstorm if read-only view returns as a separate need |
+| 26 | Impersonation-by-default UI | High cognitive cost; gimmicky for volunteer admin |
+| 27 | SOC2-grade unlimited-budget thought experiment | Carry-back items absorbed into #2 + #3; rest is enterprise creep |
+| 28 | Multi-admin race lock / advisory | Premature at single-admin reality; revisit if a second admin joins |
+| 29 | Append-only `RegistrationCorrection` stack | Elegant but a much bigger schema overhaul than the value justifies; #2 captures the audit benefit at lower cost |
+| 30 | Ownership transfer of `EventRegistration` | Subsumed by #1's actor/subject model |
+| 31 | "Invite to claim" pattern for password reset / new parents | Useful but a different feature (onboarding), not impersonation; track separately |

--- a/docs/plans/2026-05-11-001-feat-admin-on-behalf-and-audit-log-plan.md
+++ b/docs/plans/2026-05-11-001-feat-admin-on-behalf-and-audit-log-plan.md
@@ -1,0 +1,449 @@
+---
+title: "feat: admin on-behalf-of edits + universal action log"
+type: feat
+status: completed
+date: 2026-05-11
+origin: docs/brainstorms/2026-05-11-admin-on-behalf-requirements.md
+---
+
+# feat: admin on-behalf-of edits + universal action log
+
+## Summary
+
+Add an append-only `ActionLog` table, hook it into `SQLModelWithSave.save()` and `.delete_by_id()` via request-scoped `contextvars`, build a new admin route for editing any user's `EventRegistration` with a required reason, wrap the existing `/admin/users` and `/admin/families` `NiceCRUDWithSQL` pages to enforce the same reason prompt + blocklist + admin-on-admin rule, and surface admin-on-behalf changes back to the affected parent on their profile and registration pages — all in one PR.
+
+---
+
+## Problem Frame
+
+Pack 218's admins regularly need to update a parent's record on their behalf (last-minute camping trip drops, meal switches from a text, phone-number corrections), but the existing admin paths produce silent unattributed writes and the canonical `EventRegistration` case has no admin UI at all (see origin: `docs/brainstorms/2026-05-11-admin-on-behalf-requirements.md` Problem Frame for the full pain narrative).
+
+---
+
+## Requirements
+
+- R1. Append-only `ActionLog` table with `actor_user_id`, `subject_user_id`, `entity_name`, `entity_id`, `action`, `field_changes` (JSON), `created_at`, nullable `reason`.
+- R2. Every `SQLModelWithSave.save()` and `.delete_by_id()` insert exactly one `ActionLog` row in the same transaction. Self-edits (`actor == subject`) get `reason = NULL` and are logged but filtered from parent panel.
+- R3. New admin entry point for editing any user's `EventRegistration`.
+- R4. Admin can edit a permitted subset of fields on any other user's `User` profile through `/admin/users`: `first_name`, `last_name`, `phone_number`, `family_member_type`, `has_food_allergies`, `food_allergies_detail`, `has_food_intolerances`, `food_intolerances`.
+- R5. Required free-text reason when `actor ≠ subject`; empty reason rejects save.
+- R6. Blocklist for on-behalf edits: `email`, `username`, `hashed_password`, `is_admin`, `can_login`, `email_confirmed`, `email_confirmation_code`. Enforced both in UI (hidden/disabled) and at save() (rejected).
+- R7. Admin cannot use on-behalf flow against another admin's record.
+- R8. Parent-visible panel on profile and event-registration pages listing `ActionLog` entries where `subject_user_id = current_user.id` (or Family-scoped) and `actor_user_id ≠ current_user.id`.
+- R9. Parent panel ships in the same PR.
+- R10. One new Alembic migration adds `action_log` table.
+- R11. Reason prompt is shared between the new EventRegistration admin route and the `NiceCRUDWithSQL` admin wrappers.
+
+**Origin actors:** A1 Admin, A2 Parent (subject), A3 System (save hook).
+**Origin flows:** F1 Admin edits EventRegistration on-behalf, F2 Admin edits User profile on-behalf, F3 Parent views on-behalf changes, F4 Admin attempts blocked-field edit.
+**Origin acceptance examples:** AE1 (covers R2/R5), AE2 (covers R2 self-edit), AE3 (covers R6 blocklist), AE4 (covers R7 admin-on-admin), AE5 (covers R8 panel).
+
+---
+
+## Scope Boundaries
+
+- No session-swap / impersonation mode — admins always remain themselves in their own session.
+- No bulk operations, CSV import, or batch waitlist promotion in this plan (they will use the same audit substrate when added).
+- No "view as parent" read-only debugging affordance.
+- No `@side_effect(suppress_when_on_behalf=True)` decorator — defer to the first non-email side-effect.
+- No multi-admin race protection (last-write-wins is acceptable at single-admin reality).
+- No reason picklist / category curation.
+- No backfill of pre-existing writes into `ActionLog`.
+- No co-parent invite, magic-link self-service, or `Delegation` standing-proxy table.
+- No standalone "Phone Intake" page — entry points reuse the existing admin pages plus the one new event-roster route.
+
+### Deferred to Follow-Up Work
+
+- Side-effect suppression decorator: separate PR when waitlist-promotion emails or any non-email side-effect is added.
+- Co-parent invite (origin S4), magic-link self-service (origin S5), `Delegation` standing proxy (origin S7): independent brainstorms/plans.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `pack218/entities/__init__.py:14-33` — `SQLModelWithSave.save()` is the universal write path. `NiceCRUDWithSQL.update()` and `.create()` at lines 101–118 both call `item.save()`. Hook here to capture every write through one seam.
+- `pack218/entities/__init__.py:66-75` — `SQLModelWithSave.delete_by_id()` is the universal delete path. `EventRegistration` deletion in `pack218/pages/event_registration.py:41` goes through it. Hook here for delete actions.
+- `pack218/entities/models.py:232-413` — `User` model carries the blocklisted fields (`is_admin`, `hashed_password`, `username`, `email`, `can_login`, `email_confirmed`, `email_confirmation_code`) and the session resolver `User.get_current(request)` at line 402.
+- `pack218/entities/models.py:24-117` — `EventRegistration` carries the on-behalf-editable fields (`stay_friday_night`, `stay_saturday_night`, `eat_*`, `has_paid`). `subject_user_id` derives from `self.user_id` here.
+- `pack218/app.py:266-340` — existing `/admin/families`, `/admin/events`, `/admin/users` route shape using `NiceCRUDWithSQL`. New `/admin/events/{event_id}/registrations` route fits this shape.
+- `pack218/pages/utils.py:24-30` — `assert_is_admin()` is the centralized admin gate; `SessionDep` is the DB session dependency.
+- `pack218/pages/event_registration.py:24-121` — the user-facing event registration form pattern (per-family-member checkbox grid) that the new admin route mirrors at single-family scope.
+- `alembic/versions/efdb27d61ada_add_capacity_to_event.py` — convention for an Alembic migration in this repo (`op.batch_alter_table`, `sqlalchemy as sa`, `sqlmodel.sql.sqltypes`).
+- `tests/test_models.py` — current test convention: plain pytest fixtures, no DB session today. `tests/conftest.py` is essentially empty.
+
+### Institutional Learnings
+
+- None — `docs/solutions/` does not exist yet. The audit pattern from this plan is a candidate for a first entry after the work lands.
+
+### External References
+
+- Not used. The pattern (universal save-hook + actor/subject + reason) is established SQLAlchemy / SQLModel practice; the origin doc captured the relevant external grounding (RFC 8693 `act` claim, django-hijack, healthcare proxy, sudo `-u`).
+
+---
+
+## Key Technical Decisions
+
+- **Request-scoped `contextvars` for actor and reason** (resolves origin "Affects R2 [Technical] actor resolution"). `pack218.audit.current_actor: ContextVar[Optional[int]]` and `current_reason: ContextVar[Optional[str]]` are set in the request boundary and read inside `SQLModelWithSave.save()`. This avoids touching every call site's signature and matches NiceGUI's per-request model. Test-time injection is one `ContextVar.set()` call per test.
+- **Audit insert in the SAME transaction as the data write** (resolves origin "Affects R2 [Needs research] transaction boundary"). At pack scale, contention is non-issue; same-tx eliminates the orphan-log failure mode. Implementation hooks between `session.flush()` and `session.commit()` inside `save()`.
+- **Subject derivation by entity type**: `User` → `self.id`; `EventRegistration` → `self.user_id`; `Family` → `subject_id = NULL`, `entity_name='Family'`, `entity_id=family.id`. Parent panel surfaces Family-scoped rows by joining the viewer's `family_id` with `ActionLog.entity_id` where `entity_name='Family'`. No write-time fan-out.
+- **Diff capture via SQLAlchemy attribute history** — read `sqlalchemy.inspect(instance).attrs.<field>.history` between flush and commit; gives `(before, after)` per dirty field without a pre-read query. For create, `before` is `null`.
+- **`field_changes` stored as a JSON column**, not a normalized per-field row. Pack scale makes the simpler shape strictly better.
+- **New admin route `/admin/events/{event_id}/registrations`** (resolves origin "Affects R3 [Technical] admin entry point"). Cleaner separation than mingling admin-on-behalf into the user-facing `/event-registration/<id>` handler. Renders a family-grouped roster with an inline "Edit on behalf of …" affordance per row.
+- **`OnBehalfNiceCRUD` subclass wraps the existing `NiceCRUDWithSQL`** (resolves R11). Intercepts `update()` to prompt for reason in a modal when `actor.id ≠ subject.id`, sets `current_reason`, then calls super. Field-hiding for the blocklist uses Pydantic's per-call `exclude` so the admin form simply does not render those fields when the target is not the current user.
+- **Reason modal helper** (`pack218/pages/ui_components.request_reason_then(callback)`) — single reusable modal, used by both the new admin route and the `OnBehalfNiceCRUD` wrapper, so R11 ("one rule, one validation") is a code reuse fact.
+- **Block-list approach for User fields** — explicit and short; new User fields default to editable unless added to the list. An allow-list would require touching this rule every time a User field is added.
+- **Self-edits are also logged** — uniform substrate; the parent panel filters them out at read time.
+- **No new dependencies** — SQLModel, SQLAlchemy, NiceGUI, Pydantic, Alembic, pytest are all already present.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- *Actor resolution inside `save()`* (origin R2 Technical): use request-scoped `contextvars` set in the request chrome and read inside save.
+- *Transaction boundary for audit insert* (origin R2 Needs research): same transaction as the data write.
+- *Admin entry point for EventRegistration* (origin R3 Technical): new dedicated `/admin/events/{event_id}/registrations` route.
+- *Reason prompt UX* (origin R5 Technical): modal-before-save via a shared helper, used by both new admin route and `OnBehalfNiceCRUD`.
+- *Parent panel placement* (origin R8 Technical): top of profile page and inline above the user's own EventRegistration view, collapsible, last 30 days.
+
+### Deferred to Implementation
+
+- Exact `field_changes` JSON shape for `delete` actions — likely `{"_action": "delete", "snapshot": {…}}` capturing the full row at delete time, but the precise schema can be finalized when writing U3.
+- Whether the audit hook needs to handle `pre_save()` validation failures specially. Likely fine: `pre_save` raises before flush, so no audit row is written — but verify in U3 tests.
+- Whether `NiceCRUDWithSQL.create` needs a reason prompt for "create-on-behalf" (admin creates a new family member for someone else). MVP can require admin to set `family_id` to their own first or treat all admin creates as actor=admin/subject=admin until a clear use case emerges.
+
+---
+
+## Output Structure
+
+```
+pack218/
+├── audit/                              # NEW
+│   ├── __init__.py                     # NEW — exports current_actor, current_reason, record_change, AuditError
+│   └── hooks.py                        # NEW — diff helpers, save/delete hook bodies
+├── entities/
+│   ├── __init__.py                     # MODIFY — wire save/delete into audit hooks
+│   └── models.py                       # MODIFY — add ActionLog model
+├── pages/
+│   ├── admin_event_registration.py     # NEW — admin roster + edit-on-behalf form
+│   ├── admin_overrides.py              # NEW — OnBehalfNiceCRUD subclass + blocklist
+│   ├── ui_components.py                # MODIFY — add request_reason_then() modal helper
+│   ├── profile.py                      # MODIFY — mount on-behalf-changes panel
+│   ├── event_registration.py           # MODIFY — mount on-behalf-changes panel for this user's row
+│   └── on_behalf_panel.py              # NEW — the parent-visible panel component
+└── app.py                              # MODIFY — set current_actor in chrome(), add /admin/events/{id}/registrations route, switch /admin/users + /admin/families to OnBehalfNiceCRUD
+alembic/versions/
+└── <hash>_add_action_log.py            # NEW — migration creating action_log table
+tests/
+├── conftest.py                         # MODIFY — add in-memory SQLite session fixture, actor-context fixture
+├── test_audit_log.py                   # NEW — model + hook unit tests
+└── test_on_behalf.py                   # NEW — blocklist, admin-on-admin, reason-required, panel filter
+AGENTS.md                                # NEW or MODIFY — write-path convention note
+```
+
+---
+
+## Implementation Units
+
+### U1. ActionLog model + Alembic migration
+
+**Goal:** Add the append-only audit table and a thin model class.
+
+**Requirements:** R1, R10.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `pack218/entities/models.py` (add `ActionLog` class)
+- Create: `alembic/versions/<hash>_add_action_log.py` (autogenerated then reviewed)
+- Test: `tests/test_audit_log.py` (new)
+- Modify: `tests/conftest.py` (add `db_session` fixture using `sqlite:///:memory:`)
+
+**Approach:**
+- `ActionLog(SQLModelWithSave, table=True)` with fields: `id` (PK), `actor_user_id` (int, FK to `user.id`, nullable for system actions), `subject_user_id` (int, FK to `user.id`, nullable for Family-scoped writes), `entity_name` (str), `entity_id` (int), `action` (str enum-like: `"create" | "update" | "delete"`), `field_changes` (JSON column, SQLAlchemy `JSON` type), `reason` (str, nullable), `created_at` (datetime, default_factory `datetime.now`).
+- Index on `(subject_user_id, created_at)` for the parent panel query; index on `(entity_name, entity_id)` for Family-scoped lookups.
+- Generate migration via `alembic revision --autogenerate -m "add action log"` then manually verify the indexes and JSON column type follow the convention from `alembic/versions/efdb27d61ada_add_capacity_to_event.py`.
+- Test fixture `db_session` in `conftest.py` uses `create_engine("sqlite:///:memory:")` and `SQLModel.metadata.create_all(engine)` per test.
+
+**Patterns to follow:**
+- Field shape and Alembic migration style: `pack218/entities/models.py:24-46` (`EventRegistration`) and `alembic/versions/efdb27d61ada_add_capacity_to_event.py`.
+
+**Test scenarios:**
+- Happy path: Construct an `ActionLog` with all fields populated, save through the in-memory session, query by `subject_user_id` and `actor_user_id`, assert both indexes return the row.
+- Happy path: Construct an `ActionLog` with `subject_user_id=None` (Family-scoped), `entity_name='Family'`, `entity_id=42`; assert it persists and a join query returning rows for `entity_name='Family' AND entity_id=42` returns it.
+- Edge case: `field_changes={}` (no diff) — row still inserts. Edge case: `reason=None` — row still inserts.
+- Edge case: Migration apply + downgrade round-trip leaves no residual table (verify with `alembic upgrade head` then `alembic downgrade -1` in a tmp DB).
+
+**Verification:**
+- `pytest tests/test_audit_log.py` green.
+- Migration applies cleanly against a fresh DB and round-trips down.
+
+---
+
+### U2. Audit module (contextvars, diff helpers, record() function)
+
+**Goal:** Implement the request-scoped actor and reason primitives plus a `record_change(session, instance, action)` helper that captures the diff and inserts an `ActionLog` row.
+
+**Requirements:** R2, R5 (substrate only — enforcement is U3).
+
+**Dependencies:** U1.
+
+**Files:**
+- Create: `pack218/audit/__init__.py` — exports `current_actor`, `current_reason`, `record_change`, `AuditError`.
+- Create: `pack218/audit/hooks.py` — diff helpers, `record_change` body.
+- Test: `tests/test_audit_log.py` (extend)
+
+**Approach:**
+- `current_actor: ContextVar[Optional[int]] = ContextVar("current_actor", default=None)` holds the user id of whoever initiated the request.
+- `current_reason: ContextVar[Optional[str]] = ContextVar("current_reason", default=None)` is set by the UI before calling `save()` when the admin is acting on behalf of someone else.
+- `subject_for(instance)` returns `(entity_name, entity_id, subject_user_id)` keyed by class: `User` → `(self.id)`, `EventRegistration` → `(self.user_id)`, `Family` → `(None)`.
+- `diff_for(instance, action)` uses `sqlalchemy.inspect(instance).attrs.<field>.history` to produce `{field: [before, after]}` between flush and commit. For `create`, `before` is null. For `delete`, capture a full snapshot via `instance.dict()` (or model_dump for Pydantic v2) under `{"_action": "delete", "snapshot": {…}}`.
+- `record_change(session, instance, action)` composes the above, reads `current_actor` / `current_reason`, inserts a row via `session.add(ActionLog(...))`. Does NOT commit — caller (`save()` in U3) commits the surrounding transaction.
+
+**Patterns to follow:**
+- `pack218/entities/__init__.py:20-33` for the session-handling shape (caller may pass a session or it creates one).
+
+**Test scenarios:**
+- Happy path: `current_actor.set(1)`, build and persist a `User` with new fields, `record_change` produces `{first_name: [None, "Sarah"], …}` for create.
+- Happy path: Load a User, change `phone_number`, call `record_change(action="update")`, diff is `{phone_number: ["555-old", "555-new"]}`.
+- Happy path: `current_actor.set(None)` produces an `ActionLog` row with `actor_user_id=NULL` (system writes are allowed but discouraged; never raise here).
+- Edge case: No dirty attributes on update → `field_changes={}` row still written (uniform substrate).
+- Edge case: `EventRegistration` instance → subject_user_id resolves to `self.user_id`. `Family` instance → subject_user_id is NULL; entity_id resolved.
+- Edge case: Delete action serializes a snapshot, not a diff.
+- Integration: Two distinct test workers via `ContextVar.run()` see independent actor values (verifies no global leakage).
+
+**Verification:**
+- All test scenarios green.
+- `record_change` does no I/O of its own beyond `session.add` (no flush, no commit).
+
+---
+
+### U3. Audit hooks in `SQLModelWithSave.save()` and `.delete_by_id()` + on-behalf authorization rules
+
+**Goal:** Wire `record_change` into the universal write path, and enforce the on-behalf rules (required reason, blocklist, admin-on-admin block) at the save boundary so they cannot be bypassed by any UI path.
+
+**Requirements:** R2, R5, R6, R7.
+
+**Dependencies:** U2.
+
+**Files:**
+- Modify: `pack218/entities/__init__.py` (`SQLModelWithSave.save` and `SQLModelWithSave.delete_by_id`)
+- Modify: `pack218/audit/__init__.py` (add `BLOCKLISTED_USER_FIELDS` constant, `enforce_on_behalf_rules` helper)
+- Test: `tests/test_on_behalf.py` (new)
+
+**Approach:**
+- `save()` becomes: `self.pre_save(); session.add(self); session.flush(); enforce_on_behalf_rules(session, self, action); record_change(session, self, action); session.commit(); session.refresh(self)`. Two new lines, same control flow, same exception semantics.
+- `delete_by_id()` becomes: load → `enforce_on_behalf_rules(session, instance, "delete")` → `record_change(session, instance, "delete")` → `session.delete(instance)` → `session.commit()`.
+- `enforce_on_behalf_rules(session, instance, action)` reads `current_actor`. Compute `subject_user_id` via `audit.subject_for(instance)`. When `current_actor != subject_user_id` AND `subject_user_id is not None` (self-edit shortcut; Family writes count as on-behalf when actor isn't a family member, see below):
+  1. Reason check: `current_reason.get()` must be non-empty; else raise `AuditError("Reason is required when editing another user's record")` (covers AE1).
+  2. Blocklist check: if `instance` is a `User`, compute the dirty fields from `inspect(instance).attrs`; if any dirty field name is in `BLOCKLISTED_USER_FIELDS` (`{"email", "username", "hashed_password", "is_admin", "can_login", "email_confirmed", "email_confirmation_code"}`), raise `AuditError("These fields can only be changed by the user themselves: …")` (covers AE3).
+  3. Admin-on-admin check: if `instance` is a `User` and `instance.is_admin is True` and current_actor's `is_admin is True`, raise `AuditError("On-behalf-of edits cannot target another admin's record")` (covers AE4).
+- For Family writes: `subject_user_id` is None, but on-behalf still applies when `current_actor` is not a member of `instance` (looked up via `User.family_id` for actor). When actor is a family member, treat as self-edit. When actor is not, require reason. Blocklist for Family: empty for MVP (all Family fields are editable).
+- `AuditError` extends `Exception`; UI catches it via the existing notify-on-error pattern.
+
+**Execution note:** Test-first for the enforcement rules — write the failing on-behalf and blocklist tests in `tests/test_on_behalf.py` before modifying `save()` and `delete_by_id()`. The hook changes are simple enough that risk is concentrated in the rule logic, where each AE maps to a test.
+
+**Patterns to follow:**
+- The existing `save()` already wraps `make_the_save()` in a `with Session(engine) as session` block; preserve that exactly.
+
+**Test scenarios:**
+- **Covers AE1.** Happy path: `current_actor.set(admin_id); current_reason.set("Sarah texted")` then mutate Sarah's EventRegistration and `.save()` → succeeds; `ActionLog` row has `actor=admin, subject=sarah, reason="Sarah texted"`.
+- **Covers AE1.** Error path: same setup but `current_reason.set(None)` → `AuditError` raised; assert no `ActionLog` row exists for that subject post-rollback.
+- **Covers AE1.** Error path: `current_reason.set("")` (empty string) → `AuditError` raised; same assertion.
+- **Covers AE2.** Happy path: `current_actor.set(sarah_id); current_reason.set(None)`, Sarah edits her own profile, `.save()` succeeds, `ActionLog` row has `actor=sarah, subject=sarah, reason=NULL`.
+- **Covers AE3.** Error path: admin tries to dirty `Sarah.email` with reason set; `AuditError` raised; assert `Sarah.email` in DB is unchanged.
+- **Covers AE3.** Error path: admin tries to dirty `Sarah.is_admin` with reason set; `AuditError`.
+- **Covers AE4.** Error path: admin Dave tries to edit admin Lisa's profile with reason set → `AuditError`.
+- Happy path: admin edits a Family the admin is not a member of, with reason → succeeds; `ActionLog` row has `subject_user_id=NULL, entity='Family', entity_id=family.id`.
+- Edge case: admin edits their OWN family (same `family_id`) with no reason → succeeds as self-edit.
+- Edge case: `delete_by_id` for someone else's EventRegistration with reason set → succeeds; `ActionLog` action='delete', snapshot present.
+- Edge case: `delete_by_id` with no reason while `current_actor != subject` → `AuditError`.
+- Integration: Use the in-memory session fixture and exercise the full `save()` path; confirm flush+enforce+record+commit ordering by introspecting `inspect()` history during the hook (not just before save).
+
+**Verification:**
+- All test scenarios green.
+- `assert_is_admin` paths in `pack218/app.py` are not touched — admin gating still happens per page; this unit adds an additional, save-boundary safety net.
+
+---
+
+### U4. Admin route: `/admin/events/{event_id}/registrations` + edit-on-behalf form
+
+**Goal:** Build the new admin entry point for editing any user's `EventRegistration`. Roster view with family grouping; inline edit affordance opens a modal pre-filled with current values + required reason field.
+
+**Requirements:** R3, R5, R7, R11.
+
+**Dependencies:** U3 (so the save path enforces rules even if the UI is misused).
+
+**Files:**
+- Create: `pack218/pages/admin_event_registration.py`
+- Modify: `pack218/app.py` (register the new route)
+- Modify: `pack218/pages/ui_components.py` (add `request_reason_then(on_confirm)` shared modal helper)
+- Test: `tests/test_on_behalf.py` (extend)
+
+**Approach:**
+- Route signature: `@ui.page('/admin/events/{event_id}/registrations') def admin_event_registrations_page(request: Request, session: SessionDep, event_id: int)`.
+- Calls `assert_is_admin(request, session)` first.
+- Renders the event's roster grouped by `Family`, mirroring the visual shape of `pack218/pages/event_registration.py:78-117` but read-only by default. Each row has an "Edit on behalf of …" button.
+- Clicking the button opens a modal with the same checkbox grid (`stay_*`, `eat_*`, `has_paid`) pre-filled from the current `EventRegistration`, plus a required `Reason` text input below the grid.
+- Modal "Save" button:
+  1. Validates reason is non-empty (inline error if not — matches R5 origin AE1 first half).
+  2. Sets `current_reason.set(reason_value)` via a `with` block (use `contextvars.copy_context()` to ensure the value is bound for the duration of the save).
+  3. Sets the new field values on the `EventRegistration` instance.
+  4. Calls `event_registration.save(session=session)` — the audit hook records actor=current admin, subject=row's user, reason=typed text.
+  5. On `AuditError` from U3, displays the error via `ui.notify(color='negative')` without closing the modal.
+  6. On success, closes the modal and refreshes the roster.
+- A "Drop registration" affordance calls `EventRegistration.delete_by_id` after the same reason modal flow.
+- `request_reason_then(on_confirm)` is the shared modal helper: opens a small dialog with a single textarea, validates non-empty, then calls `on_confirm(reason)`. Used by U5 too.
+- Admin-on-admin gating: filter out admin users from the roster display (`User.is_admin == True` rows are still shown for completeness but the Edit button is hidden); the audit hook (U3) is the backstop if the UI is bypassed.
+
+**Patterns to follow:**
+- `pack218/app.py:266-282` for the admin page route shape with `assert_is_admin` and `chrome()`.
+- `pack218/pages/event_registration.py:62-121` for the checkbox grid UI.
+- `pack218/pages/profile.py:67-110` for the modal dialog shape (`simple_dialog`, `BUTTON_CLASSES_ACCEPT`/`CANCEL`).
+
+**Test scenarios:**
+- **Covers F1 / AE1.** Happy path: admin loads `/admin/events/1/registrations`, opens edit modal for Sarah's row, sets `eat_saturday_breakfast=False`, types reason "Sarah texted", clicks save → DB shows updated registration AND `ActionLog` row with full diff and reason. *(Test the underlying handler function, not the NiceGUI rendering loop — see Integration note in U3.)*
+- Happy path: admin drops Sarah's registration via the same flow with reason "Family pulled out".
+- Error path: admin opens modal, leaves reason blank, clicks save → inline error message; no DB change; modal stays open.
+- Error path: admin attempts to edit another admin's row via constructed payload (skip the disabled button) → `AuditError` from U3; UI shows the error.
+- Edge case: non-admin user requesting `/admin/events/1/registrations` → 403 (existing `assert_is_admin` behavior).
+- Edge case: event has zero registrations → empty roster state; no buttons.
+
+**Verification:**
+- Manual: as admin, drop a test parent's registration and verify it appears in `ActionLog` and on the parent's profile panel after U6.
+- Automated: handler-level tests green.
+
+---
+
+### U5. `OnBehalfNiceCRUD` subclass + admin pages migration
+
+**Goal:** Wrap the existing `NiceCRUDWithSQL` so `/admin/users` and `/admin/families` enforce the reason prompt, hide blocklisted fields, and let the audit hook do its job. R4 (User profile editable fields) is enforced here primarily via field-hiding.
+
+**Requirements:** R4, R5, R6, R7, R11.
+
+**Dependencies:** U3, U4 (reuses `request_reason_then` from U4).
+
+**Files:**
+- Create: `pack218/pages/admin_overrides.py` (`OnBehalfNiceCRUD` class)
+- Modify: `pack218/app.py` (swap `NiceCRUDWithSQL(basemodeltype=User, …)` → `OnBehalfNiceCRUD(basemodeltype=User, …)` at lines 273, 282, 340 — re-evaluate exact lines on the implementation pass)
+- Test: `tests/test_on_behalf.py` (extend)
+
+**Approach:**
+- `OnBehalfNiceCRUD(NiceCRUDWithSQL)` overrides `async def update(self, item)`:
+  1. Resolve current actor from `current_actor.get()`.
+  2. If `item` is a `User` and `item.id != current_actor`, configure NiceCRUDConfig to exclude `BLOCKLISTED_USER_FIELDS` from the rendered form fields before super's update logic runs.
+  3. If subject ≠ actor, call `request_reason_then(lambda reason: super().update(item))`. Set `current_reason.set(reason)` inside the callback before calling super.
+  4. If actor == subject, call super directly — no reason needed.
+- `OnBehalfNiceCRUD.create()` requires admin to be in the same Family as `item.family_id` for User creates (matches today's profile flow); otherwise treats as on-behalf-create and prompts for reason.
+- Blocklist field-hiding uses NiceCRUDConfig's `additional_exclude` parameter; the field is removed from the form before render, so the admin literally cannot edit it. The U3 save-boundary check is the backstop.
+- Admin-on-admin: if `item.is_admin is True` and `item.id != current_actor`, the update button is disabled and a tooltip explains why. U3 is the backstop.
+
+**Execution note:** Test-first for the wrapper's update flow — write a failing test that calls `OnBehalfNiceCRUD.update()` with a blocked-field diff before implementing the override.
+
+**Patterns to follow:**
+- `pack218/entities/__init__.py:78-121` for the NiceCRUDWithSQL shape.
+- `pack218/app.py:273, 282, 340` for the call sites to swap.
+
+**Test scenarios:**
+- **Covers F2 / AE1.** Happy path: admin opens `/admin/users`, edits Sarah's `phone_number`, modal prompts for reason, admin types reason, save → DB updated + ActionLog row.
+- **Covers AE3.** Error path: admin opens `/admin/users` editing Sarah → `email` field is not present in the rendered form (exclude list). If a crafted PUT smuggles `email`, U3 rejects with `AuditError`.
+- **Covers AE4.** Error path: admin opens `/admin/users` to edit admin Lisa → update button disabled or tooltip shown; bypass attempt rejected by U3.
+- Happy path: admin edits their OWN profile through `/admin/users` → no reason modal, all User fields editable.
+- Happy path: admin edits another family's `Family.emergency_contact_phone_number_1` via `/admin/families` → reason modal prompts; save records `ActionLog` with `entity='Family'`.
+- Edge case: admin edits their own family → no reason modal.
+
+**Verification:**
+- Automated: handler-level tests green.
+- Manual: as admin, edit another parent's phone and confirm the reason modal appears, then verify the ActionLog row.
+
+---
+
+### U6. Parent-visible "Changes made on my behalf" panel + AGENTS.md convention
+
+**Goal:** Render a collapsible panel on the parent's profile page and on their own `event-registration/<id>` view, listing `ActionLog` entries where `actor ≠ subject` and the subject is the current user (or `entity='Family' AND entity_id = current_user.family_id`). Add a one-paragraph convention note to AGENTS.md.
+
+**Requirements:** R8, R9.
+
+**Dependencies:** U1 (data), U3 (rows actually written).
+
+**Files:**
+- Create: `pack218/pages/on_behalf_panel.py` (`render_on_behalf_panel(user, entity_name=None, entity_id=None)`)
+- Modify: `pack218/pages/profile.py` (mount panel at top of profile view, no entity filter — shows everything on-behalf for this user)
+- Modify: `pack218/pages/event_registration.py` (mount panel scoped to `entity='EventRegistration', entity_id=this_registration.id`)
+- Create or modify: `AGENTS.md` — short convention note: "All persistent writes go through `SQLModelWithSave.save()` and `.delete_by_id()` so the audit log captures them. Raw `session.add(); session.commit()` bypasses the log and is disallowed without an explicit exemption comment."
+- Test: `tests/test_on_behalf.py` (extend)
+
+**Approach:**
+- `render_on_behalf_panel(user, entity_name=None, entity_id=None)` queries `ActionLog` with:
+  - `subject_user_id == user.id AND actor_user_id != user.id`, OR
+  - `entity_name == 'Family' AND entity_id == user.family_id AND actor_user_id != user.id`
+- When `entity_name` and `entity_id` are passed, additionally filter `(ActionLog.entity_name == entity_name AND ActionLog.entity_id == entity_id)` — the event-registration page wants only that registration's changes.
+- Order by `created_at DESC`, limit to last 30 days OR last 20 rows (whichever is larger), default-collapsed if more than 3 entries.
+- Each entry renders: admin display name (`actor.first_name actor.last_name`), date, a human-readable summary of fields changed (e.g., "changed Saturday breakfast (yes → no), overnight Saturday (yes → no)"), and the `reason` in quotes.
+- For `entity='Family'` rows, label as "changed family info" with field names.
+- For `action='delete'` rows on EventRegistration, label as "removed your registration".
+
+**Patterns to follow:**
+- `pack218/pages/profile.py:147-261` for the `@ui.refreshable` page structure and `card()` / `card_title()` shape.
+- `pack218/pages/event_registration.py:24-69` for the section structure.
+
+**Test scenarios:**
+- **Covers AE5.** Happy path: setup — admin edited Sarah's `eat_saturday_breakfast` yesterday with reason "Phone call 7pm". Sarah loads her profile → panel renders one entry with admin name, yesterday's date, "changed Saturday breakfast (yes → no)", and the reason in quotes.
+- Edge case: Sarah has zero on-behalf changes → panel renders an empty state ("No changes have been made on your behalf.") OR is hidden (pick one in implementation; test expectation matches).
+- Edge case: Sarah has a self-edit yesterday → panel does NOT show it (filter `actor_user_id != user.id`).
+- Edge case: Admin edited Sarah's `Family.emergency_contact_phone_number_1` — Sarah AND every other member of Sarah's family see it on their own profile panels.
+- Edge case: Panel on `/event-registration/<id>` only shows entries scoped to that specific registration's id.
+- Edge case: A registration that was deleted on-behalf yesterday — the parent visiting `/event-registration/<id>` sees a "removed your registration" row (the registration page should still render this even though the EventRegistration row no longer exists; handler must tolerate missing row by reading from ActionLog directly).
+
+**Verification:**
+- Automated: query-layer tests green; render-layer tests covered by handler-level invocation (skip pixel-level NiceGUI assertions).
+- Manual: as a non-admin parent, log in after an admin-on-behalf edit and confirm the panel shows the expected entry.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Every `.save()` call site now also touches `ActionLog`. Audit lives downstream of every page's mutation path. `chrome()` in `pack218/app.py` becomes the actor-context entry point.
+- **Error propagation:** New `AuditError` exception class. Existing `try/except` blocks in `pack218/pages/profile.py:62-63` and elsewhere catch generic `Exception` and `ui.notify` — they will handle `AuditError` naturally. New admin and override pages need explicit handling.
+- **State lifecycle risks:** Audit insert in same transaction means a failed audit insert rolls back the data write. This is the desired semantic (no orphan log rows; no silent unaudited writes). Worth a one-line note in AGENTS.md.
+- **API surface parity:** No external APIs. Internal API: every model save behavior gains a side-effect (one `ActionLog` row). Existing tests that count rows or compare DB state must be aware.
+- **Integration coverage:** Cross-layer scenarios in U3 and U4 exercise the full save path with the in-memory session fixture.
+- **Unchanged invariants:** `assert_is_admin()` still gates admin pages. `User.get_current()` and the Google-OAuth-style session resolution unchanged. The existing user-facing `/event-registration/<id>` route is unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Code path that bypasses `SQLModelWithSave.save()` silently bypasses audit | AGENTS.md convention in U6; grep for `session.add` + `session.commit` outside `SQLModelWithSave` during U3 implementation; flag any callers with a one-line comment |
+| `ContextVar` not propagated across async boundaries (NiceGUI's task scheduler) | Use `contextvars.copy_context()` at the request boundary; verify in U3 tests that a save invoked from a NiceGUI button callback sees the actor that was set in `chrome()` |
+| SQLAlchemy `inspect().attrs.history` returns empty for attributes not loaded into the session | The save() flow always has the instance loaded (it's the one being saved); document this assumption in `audit/hooks.py`. For deletes, the snapshot uses `instance.dict()` which doesn't depend on history. |
+| Same-transaction audit insert causes a deadlock or long-running tx | At pack scale (<50 families, sequential admin actions), contention is negligible. If it ever surfaces, switch to deferred insert via `after_commit` event with the row buffered in session state. Documented in `Open Questions → Deferred to Implementation`. |
+| The `OnBehalfNiceCRUD` field-hiding via `additional_exclude` may not be a supported public API on NiceCRUDConfig | Verify by reading the `niceguicrud` source at implementation time; fall back to a thin custom form if `additional_exclude` doesn't behave as needed. |
+| Parent panel showing 18 months of stale changes is noisy | Limit to 30-day window or last 20 rows by default; explicit collapse toggle. Implementation detail in U6. |
+
+---
+
+## Documentation / Operational Notes
+
+- AGENTS.md gets a short "audit log convention" paragraph (U6 covers).
+- README.md update is optional — the admin-on-behalf workflow is a feature, not a setup change.
+- Migration is additive and reversible; deploy is a straight `alembic upgrade head`. Backups (per `scripts/`) should be taken before deploy as standard practice.
+- After this lands, seed `docs/solutions/architecture-patterns/admin-on-behalf-audit-log.md` to capture the design decisions (per origin doc's institutional-knowledge note).
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-05-11-admin-on-behalf-requirements.md`
+- **Ideation:** `docs/ideation/2026-05-11-admin-impersonation-ideation.md` (S1 + S2 starter pair)
+- Universal write path: `pack218/entities/__init__.py:14-33`
+- Existing admin pages: `pack218/app.py:266-340`
+- Centralized admin gate: `pack218/pages/utils.py:24-30`
+- User-facing event registration form (visual reference for U4): `pack218/pages/event_registration.py:24-121`
+- Profile page (mount point for U6): `pack218/pages/profile.py:147-261`
+- Test convention: `tests/test_models.py`

--- a/local_dev_setup.sh
+++ b/local_dev_setup.sh
@@ -1,5 +1,4 @@
  #!/bin/bash
- ./copy_db_from_prod.sh
  ./venv_create.sh
  ./deps_sync.sh
  echo "Local development setup complete"

--- a/pack218/app.py
+++ b/pack218/app.py
@@ -27,11 +27,14 @@ from sqlmodel import Session
 from nicegui import ui, app
 import nicegui
 
+from pack218.audit import current_actor, set_actor_from_request
 from pack218.config import config
 from pack218.entities import NiceCRUDWithSQL
 from pack218.entities.models import Event, Family, User
+from pack218.pages.admin_event_registration import render_admin_event_registrations
+from pack218.pages.admin_overrides import OnBehalfNiceCRUD
 from pack218.pages.event_registration import render_page_event_registration
-from pack218.pages.home_page import render_home_page
+from pack218.pages.home_page import render_camping_trip_detail, render_home_page
 from pack218.pages.profile import render_profile_page
 from pack218.pages.ui_components import BUTTON_CLASSES_ACCEPT
 from pack218.pages.utils import SessionDep, assert_is_admin
@@ -196,20 +199,46 @@ def assert_logged_in(request: Request):
 # Pages
 
 def chrome(request: Request, session: Session):
-    
+
     redirect = assert_logged_in(request=request)
     if redirect is not None:
         return redirect
+
+    # Make the current user available to the audit hook for the duration of
+    # this request. Reads inside SQLModelWithSave.save() and .delete_by_id()
+    # pick this up via contextvars without needing any signature changes.
+    current_user = User.get_current(request=request, session=session)
+    if current_user is not None:
+        current_actor.set(current_user.id)
+    else:
+        current_actor.set(None)
+
     user_full_name = request.session.get('user', {}).get('name', 'N/A')
     
     def logout() -> None:
         ui.navigate.to('/logout')
 
+    is_real_admin = User.current_user_is_admin(request=request, session=session)
+    lens_active = is_real_admin and bool(app.storage.user.get('view_as_non_admin', False))
+    acting_admin = is_real_admin and not lens_active
+
+    def set_lens(value: bool) -> None:
+        app.storage.user['view_as_non_admin'] = bool(value)
+        ui.navigate.reload()
+
     def menu() -> None:
         with ui.header().classes(replace='row items-center') as header:
             ui.button(on_click=lambda: left_drawer.toggle(), icon='menu').props('flat color=white')
             ui.label("Pack 218 Camping").classes('text-l font-bold')
+            if lens_active:
+                ui.badge('Viewing as non-admin', color='orange').classes('ml-2')
             ui.space()
+            if is_real_admin:
+                ui.switch(
+                    'View as non-admin',
+                    value=lens_active,
+                    on_change=lambda e: set_lens(e.value),
+                ).props('dense color=orange keep-color').classes('mr-4 text-white')
             ui.label(f'Hello {user_full_name}!').classes('mr-4')
             ui.button(on_click=logout, icon='logout', text='Logout').classes('flat color=white')
 
@@ -224,12 +253,11 @@ def chrome(request: Request, session: Session):
             ui.link('Manage my profile/family', profile_page)
             # ui.link('Update my password', update_password_page)
 
-            if User.current_user_is_admin(request=request, session=session):
+            if acting_admin:
                 ui.label('Admin')
-                ui.link('Events', admin_events)
-                ui.link('Create Event', admin_events_new)
                 ui.link('Users', admin_users)
                 ui.link('Families', admin_families)
+                ui.link('Action Log', admin_action_log_page)
 
             ui.label('Log Out')
             ui.button(on_click=logout, icon='logout').props('outline round')
@@ -256,12 +284,49 @@ def profile_page(request: Request, session: SessionDep) -> None:
         return redirect
     render_profile_page(request=request, session=session)
 
+@ui.page('/camping-trip/{event_id}')
+def camping_trip_page(request: Request, session: SessionDep, event_id: int) -> None:
+    redirect = chrome(request=request, session=session)
+    if redirect is not None:
+        return redirect
+    event = Event.get_by_id(event_id, session=session)
+    if event is None:
+        ui.label('Camping trip not found.').classes('text-lg font-bold text-red-500')
+        ui.link('Back to camping trips', main_page)
+        return
+    render_camping_trip_detail(event=event, request=request, session=session)
+
 @ui.page('/event-registration/{event_id}')
 def event_registration_page(request: Request, session: SessionDep, event_id: int) -> None:
     redirect = chrome(request=request, session=session)
     if redirect is not None:
         return redirect
     render_page_event_registration(request=request, session=session, event_id=event_id)
+
+
+@ui.page('/event-registration/{event_id}/family/{family_id}')
+def event_registration_on_behalf_page(
+    request: Request, session: SessionDep, event_id: int, family_id: int
+) -> None:
+    # Only real admins may register on behalf of another family. The lens
+    # (view-as-non-admin) does not bypass this — actual privilege is required.
+    assert_is_admin(request=request, session=session)
+    redirect = chrome(request=request, session=session)
+    if redirect is not None:
+        return redirect
+    render_page_event_registration(
+        request=request, session=session, event_id=event_id, target_family_id=family_id,
+    )
+
+@ui.page('/admin/action-log')
+def admin_action_log_page(request: Request, session: SessionDep) -> None:
+    assert_is_admin(request=request, session=session)
+    redirect = chrome(request=request, session=session)
+    if redirect is not None:
+        return redirect
+    from pack218.pages.admin_action_log import render_admin_action_log
+    render_admin_action_log(session=session)
+
 
 @ui.page('/admin/families')
 def admin_families(request: Request, session: SessionDep) -> None:
@@ -270,7 +335,16 @@ def admin_families(request: Request, session: SessionDep) -> None:
     if redirect is not None:
         return redirect
     ui.label('This is the admin page to manage families.')
-    NiceCRUDWithSQL(basemodeltype=Family, basemodels=list(Family.get_all()), heading="Families")
+    OnBehalfNiceCRUD(basemodeltype=Family, basemodels=list(Family.get_all()), heading="Families")
+
+
+@ui.page('/admin/events/{event_id}/registrations')
+def admin_event_registrations_page(request: Request, session: SessionDep, event_id: int) -> None:
+    assert_is_admin(request=request, session=session)
+    redirect = chrome(request=request, session=session)
+    if redirect is not None:
+        return redirect
+    render_admin_event_registrations(session=session, event_id=event_id, request=request)
 
 @ui.page('/admin/events')
 def admin_events(request: Request, session: SessionDep) -> None:
@@ -279,25 +353,45 @@ def admin_events(request: Request, session: SessionDep) -> None:
     if redirect is not None:
         return redirect
     ui.label('This is the admin page for the events.')
+
     NiceCRUDWithSQL(basemodeltype=Event, basemodels=list(Event.get_all()), heading="Events")
 
-@ui.page('/admin/events/new')
-def admin_events_new(request: Request, session: SessionDep) -> None:
-    assert_is_admin(request=request, session=session)
-    redirect = chrome(request=request, session=session)
-    if redirect is not None:
-        return redirect
+def _render_event_form(event: Event | None, request: Request, session: Session) -> None:
+    """Shared form for creating a new event or editing an existing one."""
+    is_edit = event is not None
 
-    ui.label('Create a new Camping Event').classes('text-lg font-bold mb-2')
+    ui.label(
+        'Edit Camping Event' if is_edit else 'Create a new Camping Event'
+    ).classes('text-lg font-bold mb-2')
+
     with ui.card().classes('w-full p-4').tight():
         with ui.grid(columns=3).classes('w-full gap-4 items-start'):
-            date_input = ui.input('Date (YYYY-MM-DD)').props('type=date dense outlined').classes('w-full')
-            location_input = ui.input('Location').props('dense outlined').classes('w-full')
-            duration_input = ui.input('Duration in days', value='2').props('type=number dense outlined').classes('w-full')
-            capacity_input = ui.input('Capacity (leave empty for unlimited)').props('type=number dense outlined').classes('w-full')
-        details_input = ui.textarea('Details (markdown supported)').props('outlined').classes('w-full h-40 mt-2')
+            date_input = ui.input(
+                'Date (YYYY-MM-DD)',
+                value=(event.date if is_edit else ''),
+            ).props('type=date dense outlined').classes('w-full')
+            location_input = ui.input(
+                'Location',
+                value=(event.location if is_edit else ''),
+            ).props('dense outlined').classes('w-full')
+            duration_input = ui.input(
+                'Duration in days',
+                value=str(event.duration_in_days) if is_edit else '2',
+            ).props('type=number dense outlined').classes('w-full')
+            capacity_input = ui.input(
+                'Capacity (leave empty for unlimited)',
+                value=(str(event.capacity) if is_edit and event.capacity is not None else ''),
+            ).props('type=number dense outlined').classes('w-full')
+        details_input = ui.textarea(
+            'Details (markdown supported)',
+            value=(event.details if is_edit else ''),
+        ).props('outlined').classes('w-full h-40 mt-2')
 
-        def create_event():
+        def submit():
+            # Re-bind actor for this handler task — the GET-time ContextVar
+            # set by chrome() does not survive across NiceGUI's event loop.
+            set_actor_from_request(request=request, session=session)
+
             date_value = (date_input.value or '').strip()
             location_value = (location_input.value or '').strip()
             duration_value = duration_input.value or '2'
@@ -314,21 +408,58 @@ def admin_events_new(request: Request, session: SessionDep) -> None:
             capacity_value = capacity_input.value
             capacity = int(capacity_value) if capacity_value else None
 
-            event = Event(
-                event_type='Camping',
-                date=date_value,
-                location=location_value,
-                details=details_value,
-                duration_in_days=int(duration_days),
-                capacity=capacity,
-            )
-            event.save()
-            ui.notify('Event created')
-            ui.navigate.to('/admin/events')
+            if is_edit:
+                event.date = date_value
+                event.location = location_value
+                event.details = details_value
+                event.duration_in_days = int(duration_days)
+                event.capacity = capacity
+                event.save()
+                ui.notify('Event updated')
+                ui.navigate.to(f'/camping-trip/{event.id}')
+            else:
+                new_event = Event(
+                    event_type='Camping',
+                    date=date_value,
+                    location=location_value,
+                    details=details_value,
+                    duration_in_days=int(duration_days),
+                    capacity=capacity,
+                )
+                new_event.save()
+                ui.notify('Event created')
+                ui.navigate.to('/admin/events')
 
+        cancel_target = f'/camping-trip/{event.id}' if is_edit else '/admin/events'
         with ui.row().classes('w-full justify-end gap-2 mt-4'):
-            ui.button('Cancel', on_click=lambda: ui.navigate.to('/admin/events')).props('outline')
-            ui.button('Create Event', icon='add').on_click(create_event).classes(BUTTON_CLASSES_ACCEPT)
+            ui.button('Cancel', on_click=lambda url=cancel_target: ui.navigate.to(url)).props('outline')
+            ui.button(
+                'Save Changes' if is_edit else 'Create Event',
+                icon='save' if is_edit else 'add',
+            ).on_click(submit).classes(BUTTON_CLASSES_ACCEPT)
+
+
+@ui.page('/admin/events/new')
+def admin_events_new(request: Request, session: SessionDep) -> None:
+    assert_is_admin(request=request, session=session)
+    redirect = chrome(request=request, session=session)
+    if redirect is not None:
+        return redirect
+    _render_event_form(event=None, request=request, session=session)
+
+
+@ui.page('/admin/events/{event_id}/edit')
+def admin_events_edit(request: Request, session: SessionDep, event_id: int) -> None:
+    assert_is_admin(request=request, session=session)
+    redirect = chrome(request=request, session=session)
+    if redirect is not None:
+        return redirect
+    event = Event.get_by_id(event_id, session=session)
+    if event is None:
+        ui.label('Camping trip not found.').classes('text-lg font-bold text-red-500')
+        ui.link('Back to events', '/admin/events')
+        return
+    _render_event_form(event=event, request=request, session=session)
 
 @ui.page('/admin/users')
 def admin_users(request: Request, session: SessionDep) -> None:
@@ -337,7 +468,7 @@ def admin_users(request: Request, session: SessionDep) -> None:
     if redirect is not None:
         return redirect
     ui.label('This is the admin page to manage users.')
-    NiceCRUDWithSQL(basemodeltype=User, basemodels=list(User.get_all()), heading="Users")
+    OnBehalfNiceCRUD(basemodeltype=User, basemodels=list(User.get_all()), heading="Users")
 
 ui.run_with(
     fastapi_app,

--- a/pack218/audit/__init__.py
+++ b/pack218/audit/__init__.py
@@ -1,0 +1,38 @@
+"""Audit substrate for pack218.
+
+Hooked into ``SQLModelWithSave.save()`` and ``SQLModelWithSave.delete_by_id()``
+so every write produces one ``ActionLog`` row. Actor and reason are carried
+via request-scoped ``contextvars`` set by the request boundary in
+``pack218/app.py``; reads inside the save hook do not require any signature
+changes to existing call sites.
+
+Self-edits (``actor == subject``) get ``reason = NULL`` and are logged but
+filtered out by the parent-visible panel. Non-self edits without a reason
+raise ``AuditError`` — enforcement lives in U3 (`pack218.audit.rules`).
+"""
+
+from pack218.audit.hooks import (  # noqa: F401
+    AuditError,
+    BLOCKLISTED_USER_FIELDS,
+    current_actor,
+    current_reason,
+    diff_for,
+    enforce_on_behalf_rules,
+    is_self_edit,
+    record_change,
+    subject_for,
+)
+
+
+def set_actor_from_request(request, session=None) -> None:
+    """Re-bind ``current_actor`` for the current task.
+
+    NiceGUI event handlers (``on_click`` etc.) execute in a different async
+    task from the original GET request, so the ContextVar that ``chrome()``
+    sets during page render does not propagate. Write handlers must call
+    this helper before invoking ``.save()`` / ``.delete_by_id()`` so the
+    audit row gets ``actor_user_id`` populated correctly.
+    """
+    from pack218.entities.models import User
+    user = User.get_current(request=request, session=session)
+    current_actor.set(user.id if user is not None else None)

--- a/pack218/audit/hooks.py
+++ b/pack218/audit/hooks.py
@@ -1,0 +1,384 @@
+"""Audit substrate implementation.
+
+`SQLModelWithSave.save()` and `.delete_by_id()` call `record_change()` to write
+one `ActionLog` row per persistent mutation, attributing it to the
+request-scoped `current_actor` and the operator-supplied `current_reason`.
+`ActionLog` itself is the recursion-bypass exemption — recording would be
+infinite. See `AGENTS.md` for the universal-write-path convention.
+"""
+
+from contextvars import ContextVar
+from datetime import datetime, date
+from typing import Any, Optional, Tuple
+
+from sqlalchemy import inspect
+from sqlmodel import Session
+
+
+# Request-scoped actor and reason. Set by the request boundary in app.py
+# (chrome() or page handlers) and read inside SQLModelWithSave.save() during
+# the audit hook. Defaults to None so unit tests and offline scripts work
+# without setup.
+current_actor: ContextVar[Optional[int]] = ContextVar("pack218_current_actor", default=None)
+current_reason: ContextVar[Optional[str]] = ContextVar("pack218_current_reason", default=None)
+
+
+class AuditError(Exception):
+    """Raised when an on-behalf-of write violates the audit/authorization rules.
+
+    Caught by the UI layer (pack218/pages/*) which displays the message via
+    ui.notify(color='negative'). Distinct from generic Exception so callers
+    can match on it specifically.
+    """
+
+
+def subject_for(instance) -> Tuple[str, Optional[int], Optional[int]]:
+    """Return (entity_name, entity_id, subject_user_id) for a persistent instance.
+
+    - User → subject is the user themselves
+    - EventRegistration → subject is the registration's owner (user_id)
+    - Family → no single subject; the parent panel surfaces these to all
+      family members by joining entity_name='Family' AND entity_id with
+      the viewer's family_id
+
+    Returns (entity_name, entity_id, None) for any other model class so an
+    unknown future entity does not silently misattribute a row to a user
+    whose id happens to match the entity_id.
+    """
+    # Import locally to avoid an import cycle (models.py imports from this
+    # module once U3 wires the save hook).
+    from pack218.entities.models import User, EventRegistration, Family
+
+    entity_name = type(instance).__name__
+    entity_id = getattr(instance, "id", None)
+
+    if isinstance(instance, User):
+        return entity_name, entity_id, entity_id
+    if isinstance(instance, EventRegistration):
+        return entity_name, entity_id, getattr(instance, "user_id", None)
+    if isinstance(instance, Family):
+        return entity_name, entity_id, None
+    return entity_name, entity_id, None
+
+
+_SCALAR_TYPES = (str, int, float, bool, type(None))
+
+
+# User fields whose value must never appear in an ActionLog row. The audit log
+# records that these fields changed (so a parent can see "your email/password
+# was updated by an admin") but the actual values are redacted, because the
+# log is long-lived and visible to all admins. bcrypt hashes are credentials;
+# email_confirmation_code is a single-use bearer token; email is PII whose
+# historical values aren't useful enough to justify retaining.
+_REDACTED_USER_FIELDS = frozenset({
+    "hashed_password",
+    "email_confirmation_code",
+    "email",
+})
+
+_REDACTED_PLACEHOLDER = "<redacted>"
+
+
+def _serialize_value(value: Any) -> Any:
+    """Coerce a Python value into something JSON-serializable for ActionLog."""
+    if isinstance(value, _SCALAR_TYPES):
+        return value
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    return str(value)
+
+
+def _redact_if_sensitive(entity_name: str, field: str, value: Any) -> Any:
+    if entity_name == "User" and field in _REDACTED_USER_FIELDS:
+        return _REDACTED_PLACEHOLDER if value not in (None, "") else value
+    return _serialize_value(value)
+
+
+def _model_snapshot(instance) -> dict:
+    """Best-effort dict-of-columns snapshot for delete actions, with sensitive
+    User fields redacted."""
+    insp = inspect(instance)
+    entity_name = type(instance).__name__
+    out = {}
+    for attr in insp.mapper.column_attrs:
+        out[attr.key] = _redact_if_sensitive(
+            entity_name, attr.key, getattr(instance, attr.key, None)
+        )
+    return out
+
+
+def diff_for(instance, action: str) -> dict:
+    """Compose the field_changes JSON payload for an ActionLog row.
+
+    - create: {field: [None, value]} for every column (sensitive User fields redacted)
+    - update: {field: [before, after]} only for dirty COLUMNS (relationships skipped)
+    - delete: {"_action": "delete", "snapshot": {column: value, ...}}
+    """
+    entity_name = type(instance).__name__
+    if action == "delete":
+        return {"_action": "delete", "snapshot": _model_snapshot(instance)}
+
+    insp = inspect(instance)
+    diff: dict = {}
+
+    if action == "create":
+        for attr in insp.mapper.column_attrs:
+            if attr.key == "id":
+                continue  # id is the row identity, not a "field change"
+            value = getattr(instance, attr.key, None)
+            diff[attr.key] = [None, _redact_if_sensitive(entity_name, attr.key, value)]
+        return diff
+
+    # update — iterate only columns (NOT relationships); relationship attrs
+    # would surface stringified SQLModel objects in the JSON.
+    for attr in insp.mapper.column_attrs:
+        history = inspect(instance).attrs[attr.key].history
+        if not history.has_changes():
+            continue
+        before_raw = history.deleted[0] if history.deleted else None
+        after_raw = (
+            history.added[0]
+            if history.added
+            else getattr(instance, attr.key, None)
+        )
+        diff[attr.key] = [
+            _redact_if_sensitive(entity_name, attr.key, before_raw),
+            _redact_if_sensitive(entity_name, attr.key, after_raw),
+        ]
+    return diff
+
+
+# ---------------------------------------------------------------------------
+# On-behalf-of enforcement (U3)
+# ---------------------------------------------------------------------------
+
+
+# Fields the user themselves owns — admins cannot change them on a user's
+# behalf, even with a reason. This is enforced at the save boundary; the
+# UI further surfaces the rejection. See `pack218.audit.is_self_edit` for
+# what counts as "the user themselves" (includes same-family members).
+BLOCKLISTED_USER_FIELDS = frozenset({
+    "email",
+    "username",
+    "hashed_password",
+    "is_admin",
+    "can_login",
+    "email_confirmed",
+    "email_confirmation_code",
+})
+
+
+# A subset of the blocklist that ALSO applies at create time. These are the
+# fields whose non-default value would grant elevated capability to the new
+# user. The remaining blocklist members (email, username, hashed_password)
+# are part of normal user setup and an admin must be able to set them when
+# creating an account for someone who hasn't logged in yet (matches the
+# PowerSchool admin-creates-parent pattern from the origin doc).
+_CREATE_TIME_BLOCKED_FIELDS = frozenset({
+    "is_admin",
+    "email_confirmed",
+})
+
+
+_USER_SAFE_DEFAULTS_FOR_CREATE = {
+    "is_admin": False,
+    "email_confirmed": False,
+}
+
+
+def is_self_edit(session: Session, instance, actor_id: int) -> bool:
+    """Self-edit semantics for the entities we audit.
+
+    - User: same user OR same family (using the persisted family_id, not the
+      possibly-being-changed in-memory value — otherwise an admin could
+      reassign a user into their own family and bypass enforcement).
+    - EventRegistration: actor IS the registration's owner OR they share a
+      family. Direct identity match short-circuits the DB lookup so a stale
+      actor_id pointing at a deleted user still classifies a save of one's
+      own record as self-edit.
+    - Family: actor is a member (actor.family_id == family.id).
+
+    Wrapped in ``no_autoflush`` so the ``session.get()`` lookups don't flush
+    the in-flight dirty changes on ``instance`` (which would clear the
+    attribute history that ``diff_for`` relies on later in save()).
+    """
+    from pack218.entities.models import User, EventRegistration, Family
+
+    # Short-circuit direct identity matches BEFORE any DB lookup. This makes
+    # a parent editing their own record self-edit even if their User row has
+    # been deleted between chrome() setting current_actor and save() reading
+    # it — protecting against confusing "Reason is required" errors on a
+    # user's own profile when the session is stale.
+    if isinstance(instance, User) and instance.id == actor_id:
+        return True
+    if isinstance(instance, EventRegistration) and instance.user_id == actor_id:
+        return True
+
+    with session.no_autoflush:
+        actor = session.get(User, actor_id)
+        if actor is None:
+            return False
+
+        if isinstance(instance, User):
+            # Read the PERSISTED family_id, not the (possibly being-changed)
+            # in-memory value. An admin reassigning a user into their own
+            # family must still be classified as on-behalf so enforcement
+            # (blocklist, admin-on-admin) runs.
+            insp = inspect(instance)
+            fam_history = insp.attrs.family_id.history
+            if fam_history.has_changes():
+                persisted_family_id = (
+                    fam_history.deleted[0] if fam_history.deleted else None
+                )
+            else:
+                persisted_family_id = instance.family_id
+            if actor.family_id and persisted_family_id == actor.family_id:
+                return True
+            return False
+
+        if isinstance(instance, EventRegistration):
+            if actor.family_id:
+                subject = session.get(User, instance.user_id)
+                if subject and subject.family_id == actor.family_id:
+                    return True
+            return False
+
+        if isinstance(instance, Family):
+            return actor.family_id == instance.id
+
+        return False
+
+
+# Back-compat alias for the private name used internally. New callers should
+# import `is_self_edit` from `pack218.audit`. The underscore form is preserved
+# so existing tests that imported it still pass.
+_is_self_edit = is_self_edit
+
+
+def _blocked_user_fields_in_change(instance, action: str) -> frozenset:
+    """Return the set of blocklisted User fields this write would change."""
+    from pack218.entities.models import User
+
+    if not isinstance(instance, User):
+        return frozenset()
+
+    if action == "update":
+        insp = inspect(instance)
+        violations = set()
+        for field in BLOCKLISTED_USER_FIELDS:
+            attr = insp.attrs.get(field)
+            if attr is not None and attr.history.has_changes():
+                violations.add(field)
+        return frozenset(violations)
+
+    if action == "create":
+        # On create, only the privilege-granting subset is blocked — admin
+        # must be able to set email/username/hashed_password when bootstrapping
+        # an account for a parent who hasn't logged in yet (the PowerSchool
+        # admin-creates-parent pattern from the origin doc).
+        violations = set()
+        for field in _CREATE_TIME_BLOCKED_FIELDS:
+            default = _USER_SAFE_DEFAULTS_FOR_CREATE.get(field)
+            value = getattr(instance, field, default)
+            if value != default:
+                violations.add(field)
+        return frozenset(violations)
+
+    # action == "delete" — blocklist doesn't apply; the action itself is auditable
+    return frozenset()
+
+
+def _is_admin_target(session: Session, instance) -> bool:
+    """True if the write targets an admin's record (User or their EventRegistration)."""
+    from pack218.entities.models import User, EventRegistration
+
+    if isinstance(instance, User):
+        return bool(getattr(instance, "is_admin", False))
+    if isinstance(instance, EventRegistration):
+        with session.no_autoflush:
+            subject = session.get(User, instance.user_id)
+            return bool(subject and subject.is_admin)
+    return False
+
+
+def enforce_on_behalf_rules(session: Session, instance, action: str) -> None:
+    """Raise AuditError if this write violates the on-behalf-of rules.
+
+    Called from SQLModelWithSave.save() and .delete_by_id() between pre_save
+    and flush. Reads current_actor / current_reason from contextvars.
+
+    When current_actor is None (offline scripts, tests without setup), no
+    rules are enforced; record_change will log the row with actor_user_id=NULL.
+    """
+    from pack218.entities.models import Event
+
+    actor_id = current_actor.get()
+    if actor_id is None:
+        return
+
+    # Event is shared trip metadata, not a personal record — the on-behalf-of
+    # rules (reason required, blocklist, admin-on-admin) don't apply. The
+    # write is still recorded in action_log so we keep the audit trail.
+    if isinstance(instance, Event):
+        return
+
+    if is_self_edit(session, instance, actor_id):
+        return
+
+    # ON-BEHALF-OF write
+
+    reason = (current_reason.get() or "").strip()
+    if not reason:
+        raise AuditError("Reason is required when editing another user's record")
+
+    blocked = _blocked_user_fields_in_change(instance, action)
+    if blocked:
+        raise AuditError(
+            "These fields can only be changed by the user themselves: "
+            + ", ".join(sorted(blocked))
+        )
+
+    # Admin-on-admin: applies to User AND EventRegistration whose owner is an
+    # admin. Family is excluded — multi-admin households are a real shape, and
+    # the admin-on-admin policy is about acting on someone's personal record,
+    # not their shared family info.
+    if _is_admin_target(session, instance):
+        raise AuditError("On-behalf-of edits cannot target another admin's record")
+
+
+def record_change(
+    session: Session,
+    instance,
+    action: str,
+    field_changes: Optional[dict] = None,
+) -> None:
+    """Insert one ActionLog row for the given write.
+
+    Does NOT flush or commit — the caller (SQLModelWithSave.save / .delete_by_id)
+    owns the surrounding transaction. ActionLog instances themselves are
+    skipped to prevent infinite recursion.
+
+    ``field_changes`` may be passed pre-computed (the save() hook does this
+    because it needs the diff BEFORE flush, while attribute history is still
+    intact). When omitted, the diff is computed here.
+    """
+    from pack218.entities.models import ActionLog
+
+    if isinstance(instance, ActionLog):
+        return
+
+    if field_changes is None:
+        field_changes = diff_for(instance, action)
+
+    entity_name, entity_id, subject_user_id = subject_for(instance)
+
+    log = ActionLog(
+        actor_user_id=current_actor.get(),
+        subject_user_id=subject_user_id,
+        entity_name=entity_name,
+        entity_id=entity_id,
+        action=action,
+        field_changes=field_changes,
+        reason=current_reason.get(),
+    )
+    session.add(log)

--- a/pack218/entities/__init__.py
+++ b/pack218/entities/__init__.py
@@ -2,6 +2,7 @@ from typing import TypeVar, Optional, Type, Sequence
 
 from nicegui import ui
 from niceguicrud import NiceCRUD, NiceCRUDConfig
+from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import SQLModel, Session, select
 from pack218.persistence.engine import engine
@@ -17,14 +18,63 @@ class SQLModelWithSave(SQLModel):
         # Override this method to add custom logic like validation before saving
         pass
 
-    def save(self, session: Session = None):
+    def save(self, session: Optional[Session] = None) -> None:
+        # Local imports inside make_the_save avoid an import cycle:
+        # pack218.audit.hooks imports models which import this module.
         def make_the_save():
+            from pack218.audit import (
+                diff_for,
+                enforce_on_behalf_rules,
+                record_change,
+            )
+            from pack218.entities.models import ActionLog
+
+            is_action_log = isinstance(self, ActionLog)
+
+            # Audit log rows bypass enforcement and self-recording — without
+            # this the audit hook would recurse forever. ActionLog rows must
+            # be append-only: existing rows are rejected so the log cannot be
+            # rewritten through the same primitive that wrote it.
+            if is_action_log:
+                if sa_inspect(self).persistent or getattr(self, "id", None) is not None:
+                    raise RuntimeError(
+                        "ActionLog rows are append-only; "
+                        "cannot update an existing audit row"
+                    )
+                self.pre_save()
+                # audit: bypassed because ActionLog rows must not self-audit (recursion guard)
+                session.add(self)
+                session.commit()
+                session.refresh(self)
+                return
+
+            # Determine action BEFORE state changes.
+            state = sa_inspect(self)
+            is_create = state.transient or state.pending
+            action = "create" if is_create else "update"
+
+            # 1. Existing validation hook.
+            self.pre_save()
+
+            # 2. Capture diff BEFORE enforce. Some enforce paths read related
+            #    rows (e.g., the actor's User row) which could otherwise
+            #    trigger autoflush and clear the dirty-attribute history.
+            field_changes = diff_for(self, action)
+
+            # 3. Enforce on-behalf rules (raises AuditError on violation).
+            enforce_on_behalf_rules(session, self, action)
+
+            # 4. Write the row.
             session.add(self)
+            session.flush()  # populate id
+
+            # 5. Record the audit row in the same transaction. record_change
+            #    accepts the pre-flush diff so dirty-attribute history stays
+            #    intact and live + tested code paths converge.
+            record_change(session, self, action, field_changes=field_changes)
+
             session.commit()
             session.refresh(self)
-
-        # Validation
-        self.pre_save()
 
         if session is None:
             with Session(engine) as session:
@@ -63,9 +113,29 @@ class SQLModelWithSave(SQLModel):
 
 
     @classmethod
-    def delete_by_id(cls: Type[T], id: int, session: Optional[Session] = None):
-        def execute_query(s: Session) -> Optional[T]:
+    def delete_by_id(cls: Type[T], id: int, session: Optional[Session] = None) -> None:
+        def execute_query(s: Session) -> None:
+            from pack218.audit import (
+                diff_for,
+                enforce_on_behalf_rules,
+                record_change,
+            )
+            from pack218.entities.models import ActionLog
+
             instance = cls.get_by_id(id=id, session=s, raise_if_not_found=True)
+
+            # ActionLog rows are append-only — refuse to delete one through
+            # the universal primitive even though we could technically do so.
+            if isinstance(instance, ActionLog):
+                raise RuntimeError(
+                    "ActionLog rows are append-only; delete_by_id is not allowed"
+                )
+
+            enforce_on_behalf_rules(s, instance, "delete")
+            # Capture the snapshot before deletion clears the row.
+            field_changes = diff_for(instance, "delete")
+            record_change(s, instance, "delete", field_changes=field_changes)
+
             s.delete(instance)
             s.commit()
         if session is None:

--- a/pack218/entities/models.py
+++ b/pack218/entities/models.py
@@ -9,7 +9,7 @@ from typing_extensions import get_args
 from pydantic import BeforeValidator, EmailStr, computed_field
 from pydantic_extra_types.phone_numbers import PhoneNumber
 from starlette.requests import Request
-from sqlalchemy import String
+from sqlalchemy import String, Column, Index, JSON
 from collections import defaultdict
 from sqlmodel import Field, Session, select, Relationship
 
@@ -140,6 +140,7 @@ class Event(SQLModelWithSave, table=True, title="Event"):
     details: str = Field(default="", title="Details", description="textarea:Details about the event")
     duration_in_days: int = Field(default=2, title="Duration", description="Duration of the event (in days)")
     capacity: int | None = Field(default=None, title="Capacity", description="Max number of participants (null = unlimited)")
+    cancelled: bool = Field(default=False, title="Cancelled", description="Whether the trip has been cancelled")
 
     # TODO: Fix the issue with relationship so we can improve performance
     #  and remove our custom implementation: get_participants
@@ -178,11 +179,22 @@ class Event(SQLModelWithSave, table=True, title="Event"):
 
     @staticmethod
     def get_upcoming(session: Session) -> List['Event']:
-        return sorted([e for e in Event.get_all(session=session) if e.is_upcoming], key=lambda e: e.date)
+        return sorted(
+            [e for e in Event.get_all(session=session) if e.is_upcoming and not e.cancelled],
+            key=lambda e: e.date,
+        )
 
     @staticmethod
     def get_past(session: Session) -> List['Event']:
-        return [e for e in Event.get_all(session=session) if not e.is_upcoming]
+        return [e for e in Event.get_all(session=session) if not e.is_upcoming and not e.cancelled]
+
+    @staticmethod
+    def get_cancelled(session: Session) -> List['Event']:
+        return sorted(
+            [e for e in Event.get_all(session=session) if e.cancelled],
+            key=lambda e: e.date,
+            reverse=True,
+        )
 
 
 class Family(SQLModelWithSave, table=True):
@@ -412,9 +424,57 @@ class User(SQLModelWithSave, table=True):
             return False
         return current_user.is_admin
 
+    @staticmethod
+    def acting_is_admin(request: Request, session: Optional[Session] = None) -> bool:
+        """Admin status from a UI-gating perspective.
+
+        Returns False when an actual admin has toggled the "view as non-admin"
+        lens. Authorization checks (e.g. ``assert_is_admin``) must still use
+        ``current_user_is_admin`` so the lens cannot lock an admin out of the
+        toggle itself.
+
+        The lens flag lives in NiceGUI's ``app.storage.user`` (not Starlette's
+        ``request.session``) because the toggle is flipped from inside an
+        event handler that has no outbound HTTP response to write a session
+        cookie back on.
+        """
+        if not User.current_user_is_admin(request=request, session=session):
+            return False
+        try:
+            from nicegui import app as nicegui_app
+            return not bool(nicegui_app.storage.user.get('view_as_non_admin', False))
+        except Exception:
+            return True
+
     # @classmethod
     # def delete_by_id(cls: Type[T], id: int, session: Optional[Session] = None):
     #     # Ensure we're not trying to delete ourselves
     #     if id == User.get_current(request=request, session=session).id:
     #         raise ValueError("You cannot delete yourself. Ask another Admin to do it.")
     #     super().delete_by_id(id=id, session=session)
+
+
+# Audit action types
+ActionType = Literal["create", "update", "delete"]
+
+
+class ActionLog(SQLModelWithSave, table=True):
+    # Append-only audit log. One row per write through SQLModelWithSave.save() / delete_by_id().
+    # subject_user_id is null for Family-scoped writes (the panel surfaces those by joining
+    # entity_name='Family' AND entity_id with the viewer's family_id). reason is null for
+    # self-edits (actor == subject) and required when actor != subject (enforced in save()).
+    __tablename__ = "action_log"
+    __table_args__ = (
+        Index("ix_action_log_subject_created", "subject_user_id", "created_at"),
+        Index("ix_action_log_entity", "entity_name", "entity_id"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    actor_user_id: int | None = Field(default=None, foreign_key="user.id", index=True)
+    subject_user_id: int | None = Field(default=None, foreign_key="user.id")
+    entity_name: str = Field(sa_type=String)
+    entity_id: int
+    action: ActionType = Field(sa_type=String)
+    field_changes: dict = Field(default_factory=dict, sa_column=Column(JSON, nullable=False))
+    reason: str | None = Field(default=None)
+    created_at: datetime = Field(default_factory=datetime.now)

--- a/pack218/pages/admin_action_log.py
+++ b/pack218/pages/admin_action_log.py
@@ -1,0 +1,208 @@
+"""Admin view for the append-only ``action_log`` table.
+
+Mounted at ``/admin/action-log``. Lists every audited write (create / update /
+delete) with the actor, subject, target entity, action, field-level diff,
+reason, and timestamp. The view filters server-side by free-text (matches
+``reason``, ``entity_name``, field-change blob, and actor/subject names),
+action type, entity type, and result limit — so the page stays responsive
+even with a large log.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from nicegui import ui
+from sqlalchemy import String, cast
+from sqlmodel import Session, or_, select
+
+from pack218.entities.models import ActionLog, EventRegistration, User
+from pack218.pages.ui_components import card_title
+
+# A reasonable upper bound on result rows so a misclicked "All" doesn't pull
+# the entire log into the UI.
+_LIMIT_CHOICES = [50, 200, 1000, 10000]
+# ActionLog is excluded on purpose — the audit hook skips writes targeting
+# ActionLog itself (to avoid recursion), so there are no such rows to filter.
+_ENTITY_CHOICES = ["(any)", "User", "Event", "EventRegistration", "Family"]
+_ACTION_CHOICES = ["(any)", "create", "update", "delete"]
+
+
+def _user_label(user: Optional[User]) -> str:
+    if user is None:
+        return ""
+    name = f"{user.first_name or ''} {user.last_name or ''}".strip()
+    if not name:
+        name = user.email or f"user#{user.id}"
+    return f"{name},id#{user.id}"
+
+
+def _format_changes(field_changes: dict) -> str:
+    """Render the JSON diff as one ``field: old → new`` line per entry."""
+    if not field_changes:
+        return ""
+    lines = []
+    for field, change in field_changes.items():
+        if isinstance(change, dict) and 'old' in change and 'new' in change:
+            lines.append(f"{field}: {change['old']!r} → {change['new']!r}")
+        else:
+            # create / delete diffs are just `{field: value}`
+            lines.append(f"{field}: {change!r}")
+    return "\n".join(lines)
+
+
+def render_admin_action_log(session: Session) -> None:
+    """Searchable list of audit-log rows."""
+    card_title("Action Log")
+    ui.label(
+        "Append-only record of every audited write. Filter by free text, "
+        "action, or entity type."
+    ).classes('text-sm p-2')
+
+    # Filter state lives in a mutable dict so the refreshable closure can
+    # read the current values without rebinding.
+    state = {
+        'q': '',
+        'action': '(any)',
+        'entity': '(any)',
+        'limit': _LIMIT_CHOICES[0],
+    }
+
+    with ui.row().classes('w-full items-center gap-4 p-2'):
+        search_input = ui.input(
+            'Search',
+            placeholder='reason / entity / actor / subject / field change',
+        ).props('dense outlined clearable').classes('flex-grow')
+        action_select = ui.select(_ACTION_CHOICES, value='(any)', label='Action')\
+            .props('dense outlined').classes('w-40')
+        entity_select = ui.select(_ENTITY_CHOICES, value='(any)', label='Entity')\
+            .props('dense outlined').classes('w-48')
+        limit_select = ui.select(
+            _LIMIT_CHOICES, value=_LIMIT_CHOICES[0], label='Limit'
+        ).props('dense outlined').classes('w-32')
+
+    @ui.refreshable
+    def render_table():
+        # Pull filter values into the query right at render time.
+        q = (state['q'] or '').strip()
+        action_filter = state['action']
+        entity_filter = state['entity']
+        limit = state['limit']
+
+        stmt = select(ActionLog)
+        if action_filter != '(any)':
+            stmt = stmt.where(ActionLog.action == action_filter)
+        if entity_filter != '(any)':
+            stmt = stmt.where(ActionLog.entity_name == entity_filter)
+        if q:
+            # Build an OR across the textual columns. Actor / subject names
+            # live on User, so we resolve those user ids in a separate query
+            # and OR them into the main filter.
+            like = f"%{q}%"
+            matching_user_ids = session.exec(
+                select(User.id).where(
+                    or_(
+                        User.first_name.ilike(like),
+                        User.last_name.ilike(like),
+                        User.email.ilike(like),
+                    )
+                )
+            ).all()
+            or_clauses = [
+                ActionLog.reason.ilike(like),
+                ActionLog.entity_name.ilike(like),
+                # field_changes is JSON in the model, stored as TEXT in
+                # SQLite. Cast to String so ILIKE works as a substring match
+                # on the serialized blob.
+                cast(ActionLog.field_changes, String).ilike(like),
+            ]
+            if matching_user_ids:
+                or_clauses.append(ActionLog.actor_user_id.in_(matching_user_ids))
+                or_clauses.append(ActionLog.subject_user_id.in_(matching_user_ids))
+            stmt = stmt.where(or_(*or_clauses))
+
+        stmt = stmt.order_by(ActionLog.created_at.desc()).limit(limit)
+        rows_raw = session.exec(stmt).all()
+
+        # Resolve actor / subject usernames in a single batch to avoid N+1
+        # session.get() calls per row.
+        user_ids = {r.actor_user_id for r in rows_raw if r.actor_user_id} | {
+            r.subject_user_id for r in rows_raw if r.subject_user_id
+        }
+        users_by_id: dict[int, User] = {}
+        if user_ids:
+            for u in session.exec(select(User).where(User.id.in_(user_ids))).all():
+                users_by_id[u.id] = u
+
+        # For EventRegistration rows in the log, look up the event_id once per
+        # registration so the Entity column can surface "which camping trip".
+        registration_ids = {
+            r.entity_id for r in rows_raw if r.entity_name == 'EventRegistration'
+        }
+        event_id_by_registration_id: dict[int, int] = {}
+        if registration_ids:
+            for er in session.exec(
+                select(EventRegistration).where(EventRegistration.id.in_(registration_ids))
+            ).all():
+                event_id_by_registration_id[er.id] = er.event_id
+
+        columns = [
+            {'name': 'created_at', 'label': 'When', 'field': 'created_at', 'sortable': True, 'align': 'left'},
+            {'name': 'actor', 'label': 'Actor', 'field': 'actor', 'sortable': True},
+            {'name': 'subject', 'label': 'Subject', 'field': 'subject', 'sortable': True},
+            {'name': 'entity', 'label': 'Entity', 'field': 'entity', 'sortable': True},
+            {'name': 'action', 'label': 'Action', 'field': 'action', 'sortable': True},
+            {'name': 'reason', 'label': 'Reason', 'field': 'reason'},
+            {'name': 'changes', 'label': 'Field changes', 'field': 'changes'},
+        ]
+        rows = []
+        for r in rows_raw:
+            entity_label = f"{r.entity_name}#{r.entity_id}"
+            if r.entity_name == 'EventRegistration':
+                # Prefer the live registration row; for `create`/`delete`
+                # diffs the event_id is in field_changes, so fall back to that.
+                event_id = event_id_by_registration_id.get(r.entity_id)
+                if event_id is None:
+                    ev_change = (r.field_changes or {}).get('event_id')
+                    if isinstance(ev_change, dict):
+                        event_id = ev_change.get('new') or ev_change.get('old')
+                    elif isinstance(ev_change, int):
+                        event_id = ev_change
+                if event_id is not None:
+                    entity_label = f"EventRegistration#{r.entity_id},event#{event_id}"
+
+            rows.append({
+                'id': r.id,
+                'created_at': r.created_at.strftime('%Y-%m-%d %H:%M:%S') if r.created_at else '',
+                'actor': _user_label(users_by_id.get(r.actor_user_id)) if r.actor_user_id else '(system)',
+                'subject': _user_label(users_by_id.get(r.subject_user_id)) if r.subject_user_id else '',
+                'entity': entity_label,
+                'action': r.action,
+                'reason': r.reason or '',
+                'changes': _format_changes(r.field_changes or {}),
+            })
+
+        ui.label(f"{len(rows)} row(s) shown (limit {limit})").classes('text-sm italic p-2')
+        table = ui.table(columns=columns, rows=rows).props(
+            'flat dense separator="horizontal" wrap-cells'
+        ).classes('w-full')
+        # Field-changes cell can be multi-line — render with preserved
+        # whitespace so the per-field diff is readable.
+        table.add_slot('body-cell-changes', r'''
+            <q-td :props="props">
+                <pre style="white-space: pre-wrap; margin: 0; font-size: 12px;">{{ props.row.changes }}</pre>
+            </q-td>
+        ''')
+
+    def on_filter_change():
+        state['q'] = search_input.value or ''
+        state['action'] = action_select.value
+        state['entity'] = entity_select.value
+        state['limit'] = limit_select.value
+        render_table.refresh()
+
+    search_input.on('update:model-value', lambda e: on_filter_change())
+    action_select.on('update:model-value', lambda e: on_filter_change())
+    entity_select.on('update:model-value', lambda e: on_filter_change())
+    limit_select.on('update:model-value', lambda e: on_filter_change())
+
+    render_table()

--- a/pack218/pages/admin_event_registration.py
+++ b/pack218/pages/admin_event_registration.py
@@ -1,0 +1,253 @@
+"""Admin route for editing any user's EventRegistration on their behalf.
+
+Mounted at ``/admin/events/{event_id}/registrations`` from pack218.app. Renders
+the event's roster grouped by Family and gives admins an inline edit affordance
+per row — opens a modal pre-filled with the registration's current values plus
+a required reason field. Save sets ``current_reason`` and calls
+``EventRegistration.save()``; the audit hook in U3 records the actor/subject/diff
+and enforces the on-behalf-of rules.
+"""
+import logging
+from functools import partial
+
+from nicegui import ui
+from sqlmodel import Session
+from starlette.requests import Request
+
+from pack218.audit import AuditError, current_reason, set_actor_from_request
+from pack218.entities.models import Event, EventRegistration, Family, User
+from pack218.pages.ui_components import (
+    BUTTON_CLASSES_ACCEPT,
+    BUTTON_CLASSES_CANCEL,
+    card_title,
+    simple_dialog,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_REGISTRATION_FIELDS = [
+    ("stay_friday_night", "Stay Friday Night"),
+    ("stay_saturday_night", "Stay Saturday Night"),
+    ("eat_saturday_breakfast", "Saturday Breakfast"),
+    ("eat_saturday_lunch", "Saturday Lunch"),
+    ("eat_saturday_dinner", "Saturday Dinner"),
+    ("eat_sunday_breakfast", "Sunday Breakfast"),
+    ("has_paid", "Has Paid"),
+]
+
+
+def _open_edit_modal(session: Session, request: Request, event: Event, subject: User,
+                     registration: EventRegistration, refresh) -> None:
+    """Edit-on-behalf modal: reason field + every EventRegistration toggle."""
+    with simple_dialog() as dialog, ui.card():
+        with ui.card_section():
+            card_title(
+                f"Edit on behalf of {subject.first_name} {subject.last_name}", level=2
+            )
+            ui.label(f"Event: {event.date} — {event.location}").classes('text-sm')
+
+        checkboxes = {}
+        with ui.card_section():
+            for field, label in _REGISTRATION_FIELDS:
+                checkboxes[field] = ui.checkbox(
+                    label, value=getattr(registration, field)
+                )
+
+        with ui.card_section():
+            reason_input = ui.textarea(
+                "Reason (required)",
+                placeholder="e.g., 'Sarah texted at 7pm, dropping Saturday breakfast'",
+            ).classes('w-full').props('autofocus')
+
+        def confirm():
+            # Re-bind actor for this handler task — ContextVars set by
+            # chrome() during the page-render request don't propagate here.
+            set_actor_from_request(request=request, session=session)
+
+            reason = (reason_input.value or "").strip()
+            if not reason:
+                ui.notify("Reason is required", color='negative')
+                return
+
+            # Apply field changes to the persistent instance, then save through
+            # the audit-hooked save() path. current_reason is read inside save().
+            for field, _label in _REGISTRATION_FIELDS:
+                setattr(registration, field, checkboxes[field].value)
+
+            token = current_reason.set(reason)
+            try:
+                registration.save(session=session)
+            except AuditError as e:
+                ui.notify(str(e), color='negative')
+                session.rollback()
+                # Discard in-memory dirty state so a re-submit doesn't silently
+                # commit the previously-rejected values with an empty diff.
+                session.expire(registration)
+                return
+            except Exception as e:  # pragma: no cover - defensive
+                logger.exception(e)
+                ui.notify(f"Error: {e}", color='negative')
+                session.rollback()
+                session.expire(registration)
+                return
+            finally:
+                current_reason.reset(token)
+
+            ui.notify(
+                f"Updated {subject.first_name}'s registration", color='positive'
+            )
+            dialog.close()
+            refresh()
+
+        with ui.row().classes('justify-end gap-2'):
+            ui.button("Cancel", on_click=dialog.close).classes(BUTTON_CLASSES_CANCEL)
+            ui.button("Save", on_click=confirm).classes(BUTTON_CLASSES_ACCEPT)
+
+    dialog.open()
+
+
+def _confirm_drop(session: Session, request: Request, subject: User,
+                  registration: EventRegistration, refresh) -> None:
+    """Drop-with-reason: deletes the registration through the audit-hooked path."""
+    with simple_dialog() as dialog, ui.card():
+        with ui.card_section():
+            card_title(
+                f"Drop {subject.first_name}'s registration?", level=2
+            )
+            ui.label(
+                "This removes the registration. Capture why so the parent can see it."
+            ).classes('text-sm')
+
+        reason_input = ui.textarea("Reason (required)").classes('w-full').props('autofocus')
+
+        def confirm():
+            set_actor_from_request(request=request, session=session)
+
+            reason = (reason_input.value or "").strip()
+            if not reason:
+                ui.notify("Reason is required", color='negative')
+                return
+
+            token = current_reason.set(reason)
+            try:
+                EventRegistration.delete_by_id(registration.id, session=session)
+            except AuditError as e:
+                ui.notify(str(e), color='negative')
+                session.rollback()
+                return
+            except Exception as e:  # pragma: no cover - defensive
+                logger.exception(e)
+                ui.notify(f"Error: {e}", color='negative')
+                session.rollback()
+                return
+            finally:
+                current_reason.reset(token)
+
+            ui.notify(
+                f"Dropped {subject.first_name}'s registration", color='positive'
+            )
+            dialog.close()
+            refresh()
+
+        with ui.row().classes('justify-end gap-2'):
+            ui.button("Cancel", on_click=dialog.close).classes(BUTTON_CLASSES_CANCEL)
+            ui.button("Drop", on_click=confirm).classes(BUTTON_CLASSES_ACCEPT)
+
+    dialog.open()
+
+
+def render_admin_event_registrations(session: Session, event_id: int, request: Request) -> None:
+    """Roster grouped by Family with an inline edit-on-behalf affordance per row."""
+    event = Event.get_by_id(event_id, session=session)
+    if event is None:
+        ui.label(f"Event {event_id} not found").classes('text-red-500')
+        return
+
+    @ui.refreshable
+    def render_roster():
+        with ui.card().classes('w-full'):
+            card_title(f"Registrations for {event.date} — {event.location}")
+            ui.label(
+                "Edit any family member's registration on their behalf. "
+                "A reason is required and is recorded with the change."
+            ).classes('text-sm p-2')
+
+            registrations = EventRegistration.select_by_event(
+                session=session, event_id=event.id
+            )
+            if not registrations:
+                ui.label("No registrations yet for this event.").classes('p-4 italic')
+                return
+
+            # Group by family for readability.
+            by_family: dict[int, list[EventRegistration]] = {}
+            for r in registrations:
+                user = r.user(session=session)
+                if user is None:
+                    continue
+                by_family.setdefault(user.family_id or 0, []).append(r)
+
+            for family_id, regs in by_family.items():
+                family = None
+                if family_id:
+                    family = Family.get_by_id(family_id, session=session)
+                family_label = family.family_name if family else "(no family)"
+
+                with ui.card().classes('w-full mb-2'):
+                    card_title(f"Family: {family_label}", level=2)
+                    for r in regs:
+                        subject = r.user(session=session)
+                        if subject is None:
+                            continue
+
+                        with ui.row().classes('items-center w-full gap-3 p-2'):
+                            ui.label(
+                                f"{subject.first_name} {subject.last_name} "
+                                f"({subject.family_member_type})"
+                            ).classes('font-bold')
+                            summary = ", ".join(
+                                label for field, label in _REGISTRATION_FIELDS
+                                if getattr(r, field) and field != "has_paid"
+                            ) or "no meals or overnights selected"
+                            ui.label(summary).classes('text-sm')
+                            paid_label = "✅ paid" if r.has_paid else "💰 unpaid"
+                            ui.label(paid_label).classes('text-sm')
+
+                            ui.space()
+
+                            # Admin-on-admin: hide the edit affordance entirely
+                            # when the subject is an admin (audit hook still
+                            # enforces at the save boundary).
+                            if subject.is_admin:
+                                ui.label("(admin record — not editable here)")\
+                                    .classes('text-xs italic')
+                                continue
+
+                            ui.button(
+                                "Edit",
+                                icon='edit',
+                                on_click=partial(
+                                    _open_edit_modal,
+                                    session,
+                                    request,
+                                    event,
+                                    subject,
+                                    r,
+                                    render_roster.refresh,
+                                ),
+                            ).classes(BUTTON_CLASSES_ACCEPT)
+                            ui.button(
+                                "Drop",
+                                icon='delete',
+                                on_click=partial(
+                                    _confirm_drop,
+                                    session,
+                                    request,
+                                    subject,
+                                    r,
+                                    render_roster.refresh,
+                                ),
+                            ).classes(BUTTON_CLASSES_CANCEL)
+
+    render_roster()

--- a/pack218/pages/admin_overrides.py
+++ b/pack218/pages/admin_overrides.py
@@ -1,0 +1,134 @@
+"""``OnBehalfNiceCRUD`` — a thin NiceCRUDWithSQL wrapper that prompts for a
+reason when an admin saves another user's (or another family's) record.
+
+The save-boundary check in ``pack218.audit`` is the structural backstop:
+without a reason in ``current_reason``, any non-self write raises
+``AuditError``. This wrapper just gives the admin a UI path to supply the
+reason before that error fires, so the common case "admin edits Sarah's
+profile, types why, save succeeds" is a single round-trip.
+
+Blocklisted field hiding is intentionally not done here — niceguicrud's
+``additional_exclude`` is a class-level configuration, not a per-target one.
+The save-boundary still rejects any blocked-field change on a non-self
+edit, and the UI surfaces the rejection via ``ui.notify``. If a friendlier
+"the field is greyed out when editing another user" experience is needed
+later, it warrants its own brainstorm — see docs/brainstorms/2026-05-11-admin-on-behalf-requirements.md.
+"""
+import logging
+from typing import Optional
+
+from nicegui import ui
+
+from pack218.audit import (
+    AuditError,
+    current_actor,
+    current_reason,
+    is_self_edit,
+)
+from pack218.entities import NiceCRUDWithSQL
+from pack218.entities.models import Family, User
+from pack218.persistence.engine import engine
+from pack218.pages.ui_components import BUTTON_CLASSES_ACCEPT, BUTTON_CLASSES_CANCEL
+from sqlmodel import Session
+
+logger = logging.getLogger(__name__)
+
+
+async def _ask_reason_modal(target_label: str) -> Optional[str]:
+    """Open an awaitable reason modal. Returns the typed reason or None on cancel."""
+    with ui.dialog() as dialog, ui.card():
+        with ui.card_section():
+            ui.label(f"Editing on behalf of {target_label}").classes('text-lg font-bold')
+            ui.label(
+                "A reason is required when editing another user's record. "
+                "It is recorded on the change and shown to the affected user."
+            ).classes('text-sm')
+        reason_input = ui.textarea("Reason").classes('w-full').props('autofocus')
+        with ui.row().classes('justify-end gap-2'):
+            ui.button("Cancel", on_click=lambda: dialog.submit(None)).classes(BUTTON_CLASSES_CANCEL)
+            ui.button(
+                "Save",
+                on_click=lambda: dialog.submit((reason_input.value or "").strip() or None),
+            ).classes(BUTTON_CLASSES_ACCEPT)
+    return await dialog
+
+
+def _label_for_target(item) -> str:
+    if isinstance(item, User):
+        return f"{item.first_name} {item.last_name}"
+    if isinstance(item, Family):
+        return f"the {item.family_name} family"
+    return type(item).__name__
+
+
+def _is_on_behalf(actor_id: Optional[int], item) -> bool:
+    """True iff this write needs a reason. False for self-edits and no-actor cases.
+
+    Spin up a short-lived session for the lookup — NiceCRUD does not pass its
+    session into update/delete overrides, and audit.is_self_edit needs one to
+    load the actor User for the cross-family check. This session is read-only;
+    the actual write uses NiceCRUD's own session via super().update().
+    """
+    if actor_id is None:
+        return False
+    with Session(engine) as session:
+        return not is_self_edit(session, item, actor_id)
+
+
+class OnBehalfNiceCRUD(NiceCRUDWithSQL):
+    """Wraps ``NiceCRUDWithSQL`` to ask for a reason on non-self updates and deletes.
+
+    Reads ``current_actor`` from the request context (set by ``chrome()`` in
+    ``pack218.app``). For self-edits (same user, or same family for User /
+    EventRegistration / Family), forwards directly to ``super()`` with no
+    prompt. For on-behalf edits, awaits a reason via the modal, sets
+    ``current_reason``, calls ``super()``, and resets the context.
+    """
+
+    async def update(self, item):
+        actor_id = current_actor.get()
+        if not _is_on_behalf(actor_id, item):
+            return await super().update(item)
+
+        reason = await _ask_reason_modal(_label_for_target(item))
+        if reason is None:
+            ui.notify("Update cancelled — no reason provided", color='warning')
+            return
+
+        token = current_reason.set(reason)
+        try:
+            await super().update(item)
+        except AuditError as e:
+            ui.notify(str(e), color='negative')
+        except Exception as e:  # pragma: no cover - defensive
+            logger.exception(e)
+            ui.notify(f"Error: {e}", color='negative')
+        finally:
+            current_reason.reset(token)
+
+    async def delete(self, id: int):
+        actor_id = current_actor.get()
+        # delete uses just the id; load the target to determine self-edit status.
+        with Session(engine) as session:
+            target = self.basemodeltype.get_by_id(id, session=session)
+        if target is None or not _is_on_behalf(actor_id, target):
+            return await super().delete(id)
+
+        reason = await _ask_reason_modal(_label_for_target(target))
+        if reason is None:
+            ui.notify("Delete cancelled — no reason provided", color='warning')
+            return
+
+        token = current_reason.set(reason)
+        try:
+            await super().delete(id)
+        except AuditError as e:
+            ui.notify(str(e), color='negative')
+        except Exception as e:  # pragma: no cover - defensive
+            logger.exception(e)
+            ui.notify(f"Error: {e}", color='negative')
+        finally:
+            current_reason.reset(token)
+
+
+__all__ = ["OnBehalfNiceCRUD"]

--- a/pack218/pages/event_registration.py
+++ b/pack218/pages/event_registration.py
@@ -1,72 +1,184 @@
-import json
 import logging
-import re
-import uuid
 from functools import partial
 from typing import Optional
 
 from nicegui import ui
-import nicegui
-from sqlalchemy.exc import NoResultFound
 from sqlmodel import Session
-from starlette.responses import RedirectResponse
 
-from pack218.config import config
-from pack218.email import send_message
-from pack218.entities.models import EventRegistration, Event, User
+from pack218.audit import AuditError, current_reason, set_actor_from_request
+from pack218.entities.models import EventRegistration, Event, Family, User
 
+from pack218.pages.on_behalf_panel import render_on_behalf_panel
 from pack218.pages.ui_components import BUTTON_CLASSES_ACCEPT, card_title, card, simple_dialog, BUTTON_CLASSES_CANCEL
-from pack218.pages.utils import validate_new_password
 from starlette.requests import Request
 
 logger = logging.getLogger(__name__)
 
-def render_page_event_registration(request: Request, session: Session, event_id: int):
 
+def render_page_event_registration(
+    request: Request,
+    session: Session,
+    event_id: int,
+    target_family_id: Optional[int] = None,
+):
+    """Render the family-side registration form.
+
+    When ``target_family_id`` is provided, the form is rendered in
+    "on-behalf-of" mode: an actual admin is registering / updating the
+    given family's members. A required reason is collected and passed
+    through ``current_reason`` so the audit hook records the actor and
+    diff against each EventRegistration write.
+    """
     current_user = User.get_current(request=request, session=session)
     event = Event.get_by_id(event_id, session=session)
 
-    def perform_event_registration():  # local function to avoid passing username and password as arguments
+    on_behalf = target_family_id is not None
+    target_family: Optional[Family] = None
+    if on_behalf:
+        # Authorization: only real admins may act on behalf of another family.
+        # The lens (view-as-non-admin) doesn't apply here — this is a write
+        # endpoint, not just UI gating.
+        if not User.current_user_is_admin(request=request, session=session):
+            ui.label('You are not authorized to register on behalf of another family.').classes(
+                'text-lg font-bold text-red-500'
+            )
+            return
+        target_family = Family.get_by_id(target_family_id, session=session)
+        if target_family is None:
+            ui.label(f'Family {target_family_id} not found.').classes(
+                'text-lg font-bold text-red-500'
+            )
+            return
+        from sqlmodel import select
+        family_members = sorted(
+            session.exec(select(User).where(User.family_id == target_family_id)).all(),
+            key=lambda u: (u.family_member_type or '', u.first_name or ''),
+        )
+    else:
+        family_members = current_user.get_all_from_family()
+
+    reason_input = None  # set below when on_behalf
+
+    def perform_event_registration():
+        # NiceGUI runs this handler in a separate task from the original GET
+        # that called chrome() — ContextVars don't propagate, so re-bind the
+        # actor here before any save/delete fires.
+        set_actor_from_request(request=request, session=session)
+
+        if on_behalf:
+            reason = (reason_input.value or '').strip() if reason_input else ''
+            if not reason:
+                ui.notify('Reason is required when registering on behalf of another family',
+                          color='negative')
+                return
+        else:
+            reason = None
+
         has_registered_user = False
+        rejected = False
         with simple_dialog() as dialog, card():
             with ui.card_section():
-                ui.label('Thank you for registering for this event.').classes('text-lg font-bold')
+                ui.label('Registration update').classes('text-lg font-bold')
             with ui.card_section():
                 for user_id, fields in user_to_fields.items():
                     user = User.get_by_id(user_id, session=session)
-                    # Check if we should delete the registration (when all fields are False)
-                    if not any([field_checkbox.value for field_checkbox in fields.values()]):
-                        event_registration = EventRegistration.get_by_user_and_event(user_id=user_id, event_id=event_id, session=session)
-                        if event_registration:
-                            EventRegistration.delete_by_id(event_registration.id, session=session)
-                            ui.label(f"❌ Looks like {user.first_name} is no longer coming. Maybe next time!")
-                    else:
-                        event_registration = EventRegistration.get_or_create_by_user_and_event(user_id=user_id, event_id=event_id, session=session)
-                        for field_name, field_checkbox in fields.items():
-                            # First, let's see if we have a registration for this user already
-                            setattr(event_registration, field_name, field_checkbox.value)
+                    nothing_selected = not any(
+                        field_checkbox.value for field_checkbox in fields.values()
+                    )
 
-                        event_registration.save(session=session)
-                        ui.label(f"☑️ Registration completed for {user.first_name}.")
-                        has_registered_user = True
-            if has_registered_user:
+                    # Set the reason for this specific save/delete so the
+                    # audit hook attributes the change properly.
+                    token = current_reason.set(reason) if on_behalf else None
+                    try:
+                        if nothing_selected:
+                            existing = EventRegistration.get_by_user_and_event(
+                                user_id=user_id, event_id=event_id, session=session
+                            )
+                            if existing:
+                                EventRegistration.delete_by_id(existing.id, session=session)
+                                ui.label(
+                                    f"❌ {user.first_name}'s registration was removed."
+                                )
+                        else:
+                            event_registration = EventRegistration.get_or_create_by_user_and_event(
+                                user_id=user_id, event_id=event_id, session=session
+                            )
+                            for field_name, field_checkbox in fields.items():
+                                setattr(event_registration, field_name, field_checkbox.value)
+                            event_registration.save(session=session)
+                            ui.label(f"☑️ Registration saved for {user.first_name}.")
+                            has_registered_user = True
+                    except AuditError as e:
+                        rejected = True
+                        ui.label(
+                            f"⛔ {user.first_name}: {e}"
+                        ).classes('text-red-500')
+                        session.rollback()
+                    except Exception as e:  # pragma: no cover - defensive
+                        rejected = True
+                        logger.exception(e)
+                        ui.label(f"⚠️ {user.first_name}: {e}").classes('text-red-500')
+                        session.rollback()
+                    finally:
+                        if token is not None:
+                            current_reason.reset(token)
+
+            if has_registered_user and not on_behalf:
                 with ui.card_section():
-                    ui.label("Disclaimer: If we end up with more people than we can fit the group site, we're going to activate the waitlist.").classes('text-lg text-italic')
+                    ui.label(
+                        "Disclaimer: If we end up with more people than we can fit the group site, "
+                        "we're going to activate the waitlist."
+                    ).classes('text-lg text-italic')
+
             with ui.card_section():
                 ui.button('Close').on_click(dialog.close).classes(BUTTON_CLASSES_ACCEPT)
 
-        dialog.on('hide', lambda: ui.navigate.to('/'))
-        dialog.on('escape-key', lambda: ui.navigate.to('/'))
+        # After confirm: send admin back to the trip detail; family back to home.
+        next_url = (
+            f'/camping-trip/{event_id}' if on_behalf else '/'
+        )
+        dialog.on('hide', lambda url=next_url: ui.navigate.to(url))
+        dialog.on('escape-key', lambda url=next_url: ui.navigate.to(url))
         dialog.open()
+
+    # Surface admin-made on-behalf changes touching this user's records.
+    if not on_behalf:
+        render_on_behalf_panel(session=session, current_user=current_user)
 
     with ui.card().classes('w-full').tight():
         card_title('Event Registration')
         with card():
             with ui.card_section():
                 capacity_info = f" (capacity: {event.capacity})" if event.capacity else ""
-                ui.label(f"🏕️ Camping trip: {event.date} for {event.duration_in_days} days, at {event.location}{capacity_info}").classes('text-lg font-bold')
+                ui.label(
+                    f"🏕️ Camping trip: {event.date} for {event.duration_in_days} days, "
+                    f"at {event.location}{capacity_info}"
+                ).classes('text-lg font-bold')
+
+                if on_behalf:
+                    with ui.card_section():
+                        ui.label(
+                            f"🛂 Acting on behalf of family: {target_family.family_name}"
+                        ).classes('text-lg font-bold text-orange-700')
+                        ui.label(
+                            "Unchecking every option for a member removes their registration."
+                        ).classes('text-sm italic')
+                        reason_input = ui.textarea(
+                            'Reason (required)',
+                            placeholder=(
+                                "e.g., 'Sarah called and is adding Saturday Lunch'"
+                            ),
+                        ).props('outlined').classes('w-full')
+
                 with ui.card_section():
-                    ui.label('Please fill out the form below to register your family for this event')
+                    if on_behalf:
+                        ui.label(
+                            'Adjust each member below, then click Save.'
+                        )
+                    else:
+                        ui.label(
+                            'Please fill out the form below to register your family for this event'
+                        )
                     with ui.row():
 
                         user_to_fields = {}
@@ -75,47 +187,85 @@ def render_page_event_registration(request: Request, session: Session, event_id:
                             for field_name, field_checkbox in user_to_fields[user_id].items():
                                 field_checkbox.value = value
 
-                        # For each family member, create a ui.card with a form to register them
-                        for u in current_user.get_all_from_family():
-
-                            # Get the current registration
-                            current_event_registration = EventRegistration.get_by_user_and_event(user_id=u.id, event_id=event_id, session=session)
+                        for u in family_members:
+                            current_event_registration = EventRegistration.get_by_user_and_event(
+                                user_id=u.id, event_id=event_id, session=session
+                            )
 
                             user_to_fields[u.id] = {}
                             with ui.card().tight():
-                                card_title(f"{u.first_name} {u.last_name} ({u.family_member_type})", level=2)
+                                card_title(
+                                    f"{u.first_name} {u.last_name} ({u.family_member_type})",
+                                    level=2,
+                                )
                                 with ui.row():
-                                    ui.button('Select None',
-                                              on_click=partial(set_all_dates, value=False, user_id=u.id)).classes(
-                                        BUTTON_CLASSES_CANCEL)
-                                    ui.button('Select All',
-                                              on_click=partial(set_all_dates, value=True, user_id=u.id)).classes(BUTTON_CLASSES_ACCEPT)
+                                    ui.button(
+                                        'Select None',
+                                        on_click=partial(set_all_dates, value=False, user_id=u.id),
+                                    ).classes(BUTTON_CLASSES_CANCEL)
+                                    ui.button(
+                                        'Select All',
+                                        on_click=partial(set_all_dates, value=True, user_id=u.id),
+                                    ).classes(BUTTON_CLASSES_ACCEPT)
 
                                 with card():
                                     with ui.card_section():
-                                        ui.label(f"Will this family member stay overnight?")
+                                        ui.label("Will this family member stay overnight?")
                                         user_to_fields[u.id]["stay_friday_night"] = ui.checkbox(
                                             "Stay Friday Night",
-                                            value=current_event_registration is not None and current_event_registration.stay_friday_night)
+                                            value=(
+                                                current_event_registration is not None
+                                                and current_event_registration.stay_friday_night
+                                            ),
+                                        )
                                         user_to_fields[u.id]["stay_saturday_night"] = ui.checkbox(
                                             "Stay Saturday Night",
-                                            value=current_event_registration is not None and current_event_registration.stay_saturday_night)
+                                            value=(
+                                                current_event_registration is not None
+                                                and current_event_registration.stay_saturday_night
+                                            ),
+                                        )
                                     with ui.card_section():
-                                        ui.label(f"Select all the meals that you wish to be included ($5 per meal/person)")
+                                        ui.label(
+                                            "Select all the meals that you wish to be included "
+                                            "($5 per meal/person)"
+                                        )
                                         user_to_fields[u.id]["eat_saturday_breakfast"] = ui.checkbox(
                                             "Saturday Breakfast",
-                                            value=current_event_registration is not None and current_event_registration.eat_saturday_breakfast)
+                                            value=(
+                                                current_event_registration is not None
+                                                and current_event_registration.eat_saturday_breakfast
+                                            ),
+                                        )
                                         user_to_fields[u.id]["eat_saturday_lunch"] = ui.checkbox(
                                             "Saturday Lunch",
-                                            value=current_event_registration is not None and current_event_registration.eat_saturday_lunch)
+                                            value=(
+                                                current_event_registration is not None
+                                                and current_event_registration.eat_saturday_lunch
+                                            ),
+                                        )
                                         user_to_fields[u.id]["eat_saturday_dinner"] = ui.checkbox(
                                             "Saturday Night Dinner",
-                                            value=current_event_registration is not None and current_event_registration.eat_saturday_dinner)
+                                            value=(
+                                                current_event_registration is not None
+                                                and current_event_registration.eat_saturday_dinner
+                                            ),
+                                        )
                                         user_to_fields[u.id]["eat_sunday_breakfast"] = ui.checkbox(
                                             "Sunday Breakfast",
-                                            value=current_event_registration is not None and current_event_registration.eat_sunday_breakfast)
+                                            value=(
+                                                current_event_registration is not None
+                                                and current_event_registration.eat_sunday_breakfast
+                                            ),
+                                        )
 
                 with ui.card_section():
                     with ui.row():
-                        ui.button('Register').on_click(perform_event_registration).classes(BUTTON_CLASSES_ACCEPT)
-
+                        ui.button(
+                            'Save' if on_behalf else 'Register'
+                        ).on_click(perform_event_registration).classes(BUTTON_CLASSES_ACCEPT)
+                        if on_behalf:
+                            ui.button(
+                                'Cancel',
+                                on_click=lambda url=f'/camping-trip/{event_id}': ui.navigate.to(url),
+                            ).props('outline').classes('ml-2')

--- a/pack218/pages/home_page.py
+++ b/pack218/pages/home_page.py
@@ -1,9 +1,19 @@
+import logging
+
 from nicegui import ui
 
-from pack218.entities.models import EventRegistration, Event, User, Family
-from pack218.pages.ui_components import BUTTON_CLASSES_ACCEPT, table_export_buttons
+from pack218.audit import AuditError, current_reason, set_actor_from_request
+from pack218.entities.models import Event, EventRegistration, Family, User
+from pack218.pages.ui_components import (
+    BUTTON_CLASSES_ACCEPT,
+    BUTTON_CLASSES_CANCEL,
+    simple_dialog,
+    table_export_buttons,
+)
 from pack218.pages.utils import SessionDep
 from starlette.requests import Request
+
+logger = logging.getLogger(__name__)
 
 
 def render_participants_table(event: Event, request: Request, session: SessionDep):
@@ -14,8 +24,8 @@ def render_participants_table(event: Event, request: Request, session: SessionDe
     # participants = event.get_participants(session=session)
     with ui.expansion(f'Participants ({len(registrations)})', icon='expand_more').classes('w-full bg-grey-2'):
         # Generate the list of participants
-        
-        is_admin = User.get_current(request=request, session=session).is_admin
+
+        is_admin = User.acting_is_admin(request=request, session=session)
         if is_admin:
             cols = ["Family", "Participant", "Cost", "Allergies", "Email", "Phone"]
         else:
@@ -35,6 +45,7 @@ def render_participants_table(event: Event, request: Request, session: SessionDe
                 {'name': 'allergies', 'label': 'Allergies', 'field': 'allergies'},
                 {'name': 'email', 'label': 'Email', 'field': 'email'},
                 {'name': 'phone', 'label': 'Phone', 'field': 'phone'},
+                {'name': 'actions', 'label': '', 'field': 'family_id'},
             ])
         table_rows = []
         for r in sorted(registrations, key=lambda r: r.user(session=session).family.family_name):
@@ -52,18 +63,36 @@ def render_participants_table(event: Event, request: Request, session: SessionDe
                     'allergies': u.food_allergies_detail or "",
                     'email': u.contact_name_email or "",
                     'phone': u.phone_number if u.phone_number else "",
+                    'family_id': family.id if family else None,
                 })
             table_rows.append(row)
         table_export_buttons(table_columns, table_rows, filename=f"participants_event_{event.id}")
         table = ui.table(columns=table_columns, rows=table_rows).props('flat dense separator="horizontal"').classes('w-full')
+        # The body slot replaces the entire row, so the action cell is inlined.
+        # The button emits an 'edit_family' event that we route to the
+        # on-behalf-of registration page below.
         table.add_slot('body', r'''
             <q-tr :props="props" :class="props.row.waitlisted === 'Yes' ? 'bg-red-1' : ''">
                 <q-td v-for="col in props.cols" :key="col.name" :props="props">
-                    {{ col.value }}
+                    <template v-if="col.name === 'actions'">
+                        <q-btn v-if="props.row.family_id"
+                               dense flat color="primary" icon="edit" label="Edit"
+                               @click="() => $parent.$emit('edit_family', props.row.family_id)" />
+                    </template>
+                    <template v-else>
+                        {{ col.value }}
+                    </template>
                 </q-td>
             </q-tr>
         ''')
-    
+        if is_admin:
+            table.on(
+                'edit_family',
+                lambda e, event_id=event.id: ui.navigate.to(
+                    f'/event-registration/{event_id}/family/{e.args}'
+                ),
+            )
+
     if is_admin:
     # Per-family cost summary
         families_summary = {}
@@ -97,8 +126,8 @@ def render_participants_table(event: Event, request: Request, session: SessionDe
             for name in sorted(families_summary.keys()):
                 summary = families_summary[name]
                 row = {
-                    'family': name, 
-                    'total': summary['total'], 
+                    'family': name,
+                    'total': summary['total'],
                     'emails': ', '.join(sorted(summary['emails'])),
                     'phones': ', '.join(sorted(summary['phones'])),
                 }
@@ -141,7 +170,7 @@ def render_participants_table(event: Event, request: Request, session: SessionDe
         phone_numbers = sorted(phone_numbers_set)
         with ui.expansion(f'Phone numbers of participants ({len(phone_numbers)})', icon='call').classes('w-full bg-grey-2'):
             ui.textarea(value=', '.join(phone_numbers)).props('readonly').classes('w-full')
-    
+
         # Admin-only: emergency contacts & license plates by family
         families_by_id = {}
         for r in registrations:
@@ -173,88 +202,224 @@ def render_participants_table(event: Event, request: Request, session: SessionDe
                 })
             table_export_buttons(table_columns, table_rows, filename=f"emergency_contacts_event_{event.id}")
             ui.table(columns=table_columns, rows=table_rows).props('flat separator=\"horizontal\"').classes('w-full')
-                    
+
+
+def _family_is_registered_for(event: Event, current_user: User, session: SessionDep) -> bool:
+    for u in current_user.get_all_from_family():
+        if EventRegistration.get_by_user_and_event(user_id=u.id, event_id=event.id, session=session):
+            return True
+    return False
+
+
+def render_camping_trip_detail(event: Event, request: Request, session: SessionDep):
+    """Render the full detail widget for a single camping trip."""
+    current_user = User.get_current(request=request, session=session)
+    acting_admin = User.acting_is_admin(request=request, session=session)
+
+    with ui.row().classes('w-full items-center'):
+        ui.button(icon='arrow_back', on_click=lambda: ui.navigate.to('/')).props('flat').tooltip('Back to camping trips')
+        ui.label('Camping Trip List').classes('text-lg font-bold')
+        ui.space()
+        if acting_admin:
+            edit_url = f'/admin/events/{event.id}/edit'
+            ui.button(
+                'Edit', icon='edit',
+                on_click=lambda url=edit_url: ui.navigate.to(url),
+            ).props('outline color=primary').tooltip('Edit this camping trip')
+            if event.is_upcoming and not event.cancelled:
+                ui.button(
+                    'Cancel Trip', icon='cancel',
+                    on_click=lambda ev=event: _open_cancel_trip_dialog(
+                        event=ev, request=request, session=session,
+                    ),
+                ).props('outline color=red').tooltip('Cancel this trip and drop all registrations')
+
+    with ui.card().classes('w-full'):
+        capacity_info = f" (capacity: {event.capacity})" if event.capacity else ""
+        ui.label(
+            f"{event.date} for {event.duration_in_days} days, "
+            f"at {event.location}{capacity_info}"
+        ).classes('text-lg font-bold')
+
+        if event.cancelled:
+            ui.label('🚫 This trip has been cancelled.').classes(
+                'text-lg font-bold text-red-600'
+            )
+
+        if (event.details or '').strip():
+            ui.markdown(event.details).classes('w-full')
+
+        render_participants_table(event=event, request=request, session=session)
+
+        is_registered = _family_is_registered_for(event=event, current_user=current_user, session=session)
+        if is_registered:
+            ui.markdown(
+                f"Your cost: **${event.get_family_cost(session=session, family_id=current_user.family_id)}**"
+            )
+
+        if event.is_upcoming and not event.cancelled:
+            if is_registered:
+                ui.label(
+                    "🎉 You are registered! Click below to update the details of your registration"
+                ).classes('text-lg text-italic')
+            registration_page_url = f'/event-registration/{event.id}'
+            ui.button(
+                'Update registration' if is_registered else 'Register'
+            ).on_click(
+                lambda url=registration_page_url: ui.navigate.to(url)
+            ).classes(BUTTON_CLASSES_ACCEPT)
+
+
+def _open_cancel_trip_dialog(event: Event, request: Request, session: SessionDep) -> None:
+    """Confirm-and-cancel modal. Marks the event ``cancelled = True`` so the
+    trip is no longer registrable, but keeps every existing
+    ``EventRegistration`` intact — that history is what tells us who *would*
+    have come.
+
+    Server-side admin guard mirrors the button-visibility check; the audit
+    hook records the reason against the Event update.
+    """
+    if not User.current_user_is_admin(request=request, session=session):
+        ui.notify('Only admins can cancel a trip', color='negative')
+        return
+
+    with simple_dialog() as dialog, ui.card():
+        with ui.card_section():
+            ui.label(
+                f"Cancel camping trip on {event.date} at {event.location}?"
+            ).classes('text-lg font-bold')
+            ui.label(
+                "The trip moves to the Cancelled tab and can no longer be "
+                "registered to. Existing registrations are preserved for "
+                "historical reference."
+            ).classes('text-sm')
+        reason_input = ui.textarea(
+            'Reason (required)',
+            placeholder="e.g., 'Site closed due to wildfire risk'",
+        ).classes('w-full').props('outlined autofocus')
+
+        def confirm():
+            # Re-bind the actor for this event-handler task — ContextVars
+            # set in chrome() don't survive across async boundaries.
+            set_actor_from_request(request=request, session=session)
+
+            reason = (reason_input.value or '').strip()
+            if not reason:
+                ui.notify('Reason is required', color='negative')
+                return
+
+            event.cancelled = True
+            token = current_reason.set(reason)
+            try:
+                event.save(session=session)
+            except AuditError as e:
+                ui.notify(str(e), color='negative')
+                session.rollback()
+                session.expire(event)
+                return
+            except Exception as e:  # pragma: no cover - defensive
+                logger.exception(e)
+                ui.notify(f"Failed to cancel trip: {e}", color='negative')
+                session.rollback()
+                session.expire(event)
+                return
+            finally:
+                current_reason.reset(token)
+
+            ui.notify('Trip cancelled.', color='positive')
+            dialog.close()
+            ui.navigate.to('/')
+
+        with ui.row().classes('justify-end gap-2'):
+            ui.button('Keep Trip', on_click=dialog.close).classes(BUTTON_CLASSES_CANCEL)
+            ui.button('Cancel Trip', icon='cancel', on_click=confirm).classes(BUTTON_CLASSES_ACCEPT)
+
+    dialog.open()
+
+
+def _render_trip_list_item(event: Event, current_user: User, session: SessionDep, acting_admin: bool, request: Request) -> None:
+    """One clickable row in the camping-trips list."""
+    url = f'/camping-trip/{event.id}'
+    capacity_info = f" (capacity: {event.capacity})" if event.capacity else ""
+    is_registered = _family_is_registered_for(event=event, current_user=current_user, session=session)
+
+    with ui.card().classes('w-full cursor-pointer hover:bg-grey-2').on(
+        'click', lambda url=url: ui.navigate.to(url)
+    ):
+        with ui.row().classes('w-full items-center no-wrap'):
+            ui.icon(
+                'block' if event.cancelled else ('event' if event.is_upcoming else 'history')
+            ).classes('text-2xl')
+            with ui.column().classes('grow gap-0'):
+                ui.label(
+                    f"{event.date} for {event.duration_in_days} days, "
+                    f"at {event.location}{capacity_info}"
+                ).classes('text-lg font-bold')
+                if event.cancelled:
+                    ui.label('🚫 Cancelled').classes('text-sm text-italic text-red-600')
+                elif is_registered:
+                    ui.label('🎉 You are registered').classes('text-sm text-italic')
+            if acting_admin:
+                edit_url = f'/admin/events/{event.id}/edit'
+                edit_btn = ui.button(
+                    'Edit', icon='edit',
+                    on_click=lambda url=edit_url: ui.navigate.to(url),
+                ).props('flat color=primary').tooltip('Edit this camping trip')
+                # Prevent the card's row-level click handler from also firing
+                # and navigating into the trip detail page.
+                edit_btn.on('click.stop', lambda: None)
+
+                # Cancel Trip is only meaningful on still-active upcoming trips.
+                if event.is_upcoming and not event.cancelled:
+                    cancel_btn = ui.button(
+                        'Cancel Trip', icon='cancel',
+                        on_click=lambda ev=event: _open_cancel_trip_dialog(
+                            event=ev, request=request, session=session,
+                        ),
+                    ).props('flat color=red').tooltip('Cancel this trip and drop all registrations')
+                    cancel_btn.on('click.stop', lambda: None)
+            ui.icon('chevron_right').classes('text-2xl')
+
+
 def render_home_page(request: Request, session: SessionDep):
 
     current_user = User.get_current(request=request, session=session)
+    acting_admin = User.acting_is_admin(request=request, session=session)
     upcoming_events = Event.get_upcoming(session=session)
-    past_events = Event.get_past(session=session)
+    past_events = sorted(Event.get_past(session=session), key=lambda e: e.date, reverse=True)
+    cancelled_events = Event.get_cancelled(session=session)
+
+    if acting_admin:
+        with ui.row().classes('w-full justify-end mb-2'):
+            ui.button(
+                'Create new',
+                icon='add',
+                on_click=lambda: ui.navigate.to('/admin/events/new'),
+            ).classes(BUTTON_CLASSES_ACCEPT)
+
     with ui.card().classes('w-full').tight():
         with ui.tabs().classes('w-full bg-secondary text-white shadow-2') as tabs:
             one = ui.tab('Upcoming Camping Trips', icon="event")
             two = ui.tab('Past Camping Trips', icon="history")
+            three = ui.tab('Cancelled', icon="block")
         with ui.tab_panels(tabs, value=one).classes('w-full'):
             with ui.tab_panel(one):
                 if upcoming_events:
                     for event in upcoming_events:
-                        with ui.card().classes('w-full'):
-                            capacity_info = f" (capacity: {event.capacity})" if event.capacity else ""
-                            ui.label(f"{event.date} for {event.duration_in_days} days, at {event.location}{capacity_info}").classes('text-lg font-bold')
-
-                            with ui.expansion('More details', icon='expand_more').classes('w-full bg-grey-2'):
-                                ui.markdown(event.details).classes('w-full h-[calc(100vh-2rem)]')
-
-                            render_participants_table(event=event, request=request, session=session)
-
-                            # For each users in the family, check if they're registered
-                            is_registered = False
-                            for u in current_user.get_all_from_family():
-                                event_registration = EventRegistration.get_by_user_and_event(user_id=u.id, event_id=event.id, session=session)
-                                if event_registration:
-                                    is_registered = True
-                                    break
-                            if is_registered:
-                                ui.markdown(f"Your cost: **${event.get_family_cost(session=session, family_id=current_user.family_id)}**")
-                                ui.label("🎉 You are registered! Click below to update the details of your registration").classes('text-lg text-italic')
-                            registration_page_url = f'/event-registration/{event.id}'
-                            ui.button('Update registration' if is_registered else f'Register').on_click(lambda url=registration_page_url: ui.navigate.to(url)).classes(BUTTON_CLASSES_ACCEPT)
+                        _render_trip_list_item(event=event, current_user=current_user, session=session, acting_admin=acting_admin, request=request)
                 else:
                     ui.label('No upcoming events found. Come back soon!').classes('text-lg font-bold text-red-500')
 
             with ui.tab_panel(two):
                 if past_events:
-                    # Create a dropdown to select past events (sorted from most recent to oldest)
-                    sorted_past_events = sorted(past_events, key=lambda e: e.date, reverse=True)
-                    event_options = {event.id: f"{event.date} - {event.location}" for event in sorted_past_events}
-                    selected_event_id = ui.select(
-                        options=event_options,
-                        label='Select a past camping trip',
-                        value=None
-                    ).classes('w-full')
-
-                    # Container for the selected event details
-                    event_details_container = ui.column().classes('w-full')
-
-                    def show_event_details(event_id):
-                        event_details_container.clear()
-                        if event_id is None:
-                            return
-
-                        # Find the selected event
-                        selected_event = next((e for e in past_events if e.id == event_id), None)
-                        if not selected_event:
-                            return
-
-                        with event_details_container:
-                            with ui.card().classes('w-full'):
-                                capacity_info = f" (capacity: {selected_event.capacity})" if selected_event.capacity else ""
-                                ui.label(f"{selected_event.date} for {selected_event.duration_in_days} days, at {selected_event.location}{capacity_info}").classes('text-lg font-bold')
-
-                                with ui.expansion('More details', icon='expand_more').classes('w-full bg-grey-2'):
-                                    ui.markdown(selected_event.details).classes('w-full h-[calc(100vh-2rem)]')
-
-                                render_participants_table(event=selected_event, request=request, session=session)
-
-                                # For each users in the family, check if they're registered and show cost
-                                is_registered = False
-                                for u in current_user.get_all_from_family():
-                                    event_registration = EventRegistration.get_by_user_and_event(user_id=u.id, event_id=selected_event.id, session=session)
-                                    if event_registration:
-                                        is_registered = True
-                                        break
-                                if is_registered:
-                                    ui.markdown(f"Your cost: **${selected_event.get_family_cost(session=session, family_id=current_user.family_id)}**")
-
-                    selected_event_id.on_value_change(lambda e: show_event_details(e.value))
+                    for event in past_events:
+                        _render_trip_list_item(event=event, current_user=current_user, session=session, acting_admin=acting_admin, request=request)
                 else:
                     ui.label('No past events found').classes('text-lg font-bold text-red-500')
+
+            with ui.tab_panel(three):
+                if cancelled_events:
+                    for event in cancelled_events:
+                        _render_trip_list_item(event=event, current_user=current_user, session=session, acting_admin=acting_admin, request=request)
+                else:
+                    ui.label('No cancelled trips').classes('text-lg font-bold text-grey-500')

--- a/pack218/pages/on_behalf_panel.py
+++ b/pack218/pages/on_behalf_panel.py
@@ -1,0 +1,155 @@
+"""Parent-visible "Changes made on my behalf" panel.
+
+Reads ``ActionLog`` rows where the subject is the current user (or the current
+user's family, for Family-scoped writes) and the actor is someone else, then
+renders them as a small collapsible card. Drawn at the top of the profile
+page (no entity filter — shows everything) and at the top of a parent's own
+event-registration view (filtered to that registration).
+"""
+from typing import Any, Optional
+
+from nicegui import ui
+from sqlmodel import Session, or_, select
+
+from pack218.entities.models import ActionLog, User
+
+
+# Per the requirements doc: limit to last 30 days OR last 20 rows (whichever
+# is larger). At pack scale these are roughly equivalent; we just cap rows.
+_MAX_ROWS = 20
+
+
+def _humanize_field_name(field: str) -> str:
+    return field.replace("_", " ")
+
+
+def _humanize_value(value: Any) -> str:
+    if value is True:
+        return "yes"
+    if value is False:
+        return "no"
+    if value is None or value == "":
+        return "—"
+    return str(value)
+
+
+def _summarize_field_changes(changes: dict[str, Any]) -> str:
+    if not changes:
+        return "no specific fields"
+    if changes.get("_action") == "delete":
+        return "removed the record"
+    parts = []
+    for field, ba in changes.items():
+        if field == "_action":
+            continue
+        if isinstance(ba, list) and len(ba) == 2:
+            before, after = ba
+            parts.append(
+                f"{_humanize_field_name(field)} ({_humanize_value(before)} → "
+                f"{_humanize_value(after)})"
+            )
+        else:
+            parts.append(_humanize_field_name(field))
+    return ", ".join(parts)
+
+
+def _actor_label(session: Session, actor_user_id: Optional[int]) -> str:
+    if actor_user_id is None:
+        return "System"
+    actor = session.get(User, actor_user_id)
+    if actor is None:
+        return f"User #{actor_user_id}"
+    return f"{actor.first_name} {actor.last_name}"
+
+
+def _fetch_rows(
+    session: Session,
+    current_user: User,
+    entity_name: Optional[str] = None,
+    entity_id: Optional[int] = None,
+) -> list[ActionLog]:
+    # Two ways a row surfaces to this user:
+    # 1. subject_user_id == current_user.id (User / EventRegistration edits)
+    # 2. entity_name == 'Family' AND entity_id == current_user.family_id (Family edits)
+    family_clause = None
+    if current_user.family_id is not None:
+        family_clause = (
+            (ActionLog.entity_name == "Family")
+            & (ActionLog.entity_id == current_user.family_id)
+        )
+    subject_clause = ActionLog.subject_user_id == current_user.id
+
+    where = or_(subject_clause, family_clause) if family_clause is not None else subject_clause
+
+    stmt = (
+        select(ActionLog)
+        .where(where)
+        .where(ActionLog.actor_user_id != current_user.id)
+        .order_by(ActionLog.created_at.desc())
+        .limit(_MAX_ROWS)
+    )
+    if entity_name is not None and entity_id is not None:
+        stmt = stmt.where(
+            ActionLog.entity_name == entity_name,
+            ActionLog.entity_id == entity_id,
+        )
+    return list(session.exec(stmt).all())
+
+
+def render_on_behalf_panel(
+    session: Session,
+    current_user: User,
+    entity_name: Optional[str] = None,
+    entity_id: Optional[int] = None,
+) -> None:
+    """Render the parent-visible 'changes made on my behalf' panel.
+
+    Pass entity_name + entity_id to scope to a single record (e.g., one
+    EventRegistration). Omit both to show every on-behalf change touching
+    this user or their family.
+    """
+    if current_user is None:
+        return
+
+    rows = _fetch_rows(
+        session=session,
+        current_user=current_user,
+        entity_name=entity_name,
+        entity_id=entity_id,
+    )
+
+    if not rows:
+        return  # Quiet when there's nothing to show.
+
+    with ui.expansion(
+        f"📒 Changes made on your behalf ({len(rows)})", icon='history',
+    ).classes('w-full'):
+        ui.label(
+            "These are changes a pack admin made to your record(s) recently."
+        ).classes('text-sm italic')
+        for row in rows:
+            actor_label = _actor_label(session, row.actor_user_id)
+            when = row.created_at.strftime("%b %d, %Y")
+            summary = _summarize_field_changes(row.field_changes)
+
+            scope_label = row.entity_name
+            if row.entity_name == "EventRegistration":
+                scope_label = "your event registration"
+            elif row.entity_name == "User":
+                scope_label = "your profile"
+            elif row.entity_name == "Family":
+                scope_label = "your family info"
+
+            with ui.card().classes('w-full my-1'):
+                with ui.card_section():
+                    ui.label(f"{when} — {actor_label}").classes('text-sm font-bold')
+                    action_word = (
+                        "removed" if row.action == "delete"
+                        else "changed" if row.action == "update"
+                        else "created"
+                    )
+                    ui.label(
+                        f"{action_word} {scope_label}: {summary}"
+                    ).classes('text-sm')
+                    if row.reason:
+                        ui.label(f"Reason: “{row.reason}”").classes('text-sm italic')

--- a/pack218/pages/profile.py
+++ b/pack218/pages/profile.py
@@ -8,6 +8,7 @@ import nicegui
 from sqlmodel import Session
 
 from pack218.entities.models import Family, Gender, User, FamilyMemberType
+from pack218.pages.on_behalf_panel import render_on_behalf_panel
 from pack218.pages.ui_components import grid, card_title, card, BUTTON_CLASSES_ACCEPT, simple_dialog, \
     BUTTON_CLASSES_CANCEL
 from pack218.pages.utils import SessionDep
@@ -220,6 +221,9 @@ def render_profile_page(request: Request, session: SessionDep):
     def apply_family_update() -> None:
         ui.notify(f'Family updated for username {nicegui.app.storage.user.get("username")}', color='positive')
         family.save(session=session)
+
+    # Surface anything an admin has done on behalf of this parent.
+    render_on_behalf_panel(session=session, current_user=current_user)
 
     with grid():
         with card():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,32 @@
-# General configs for testing
+# Shared fixtures for the pack218 test suite.
+import pytest
+from sqlmodel import SQLModel, Session, create_engine
+
+from pack218.audit import current_actor, current_reason
+
+# Importing models registers them with SQLModel.metadata so create_all sees them.
+from pack218.entities.models import (  # noqa: F401
+    User,
+    Family,
+    Event,
+    EventRegistration,
+    ActionLog,
+)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture
+def isolated_audit_context():
+    """Reset audit contextvars after each test so they never leak between tests."""
+    actor_token = current_actor.set(None)
+    reason_token = current_reason.set(None)
+    yield
+    current_actor.reset(actor_token)
+    current_reason.reset(reason_token)

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,356 @@
+from datetime import datetime
+
+import pytest
+from sqlmodel import select
+
+from pack218.audit import (
+    AuditError,
+    current_actor,
+    current_reason,
+    diff_for,
+    record_change,
+    subject_for,
+)
+from pack218.entities.models import ActionLog, EventRegistration, Family, User
+
+
+@pytest.fixture
+def parent_user(db_session):
+    user = User(
+        first_name="Sarah",
+        last_name="Chen",
+        email="sarah@example.com",
+        hashed_password=User.hash_password("x"),
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@pytest.fixture
+def admin_user(db_session):
+    user = User(
+        first_name="Cubmaster",
+        last_name="Dave",
+        email="dave@example.com",
+        hashed_password=User.hash_password("x"),
+        is_admin=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+def test_action_log_persists_with_all_fields(db_session):
+    log = ActionLog(
+        actor_user_id=1,
+        subject_user_id=2,
+        entity_name="EventRegistration",
+        entity_id=42,
+        action="update",
+        field_changes={"eat_saturday_breakfast": [True, False]},
+        reason="Sarah texted",
+    )
+    log.save(session=db_session)
+
+    rows = db_session.exec(select(ActionLog)).all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.actor_user_id == 1
+    assert row.subject_user_id == 2
+    assert row.entity_name == "EventRegistration"
+    assert row.entity_id == 42
+    assert row.action == "update"
+    assert row.field_changes == {"eat_saturday_breakfast": [True, False]}
+    assert row.reason == "Sarah texted"
+    assert isinstance(row.created_at, datetime)
+
+
+def test_action_log_supports_family_scoped_null_subject(db_session):
+    log = ActionLog(
+        actor_user_id=1,
+        subject_user_id=None,
+        entity_name="Family",
+        entity_id=7,
+        action="update",
+        field_changes={"emergency_contact_phone_number_1": ["555-old", "555-new"]},
+        reason="Mom updated her number",
+    )
+    log.save(session=db_session)
+
+    rows = db_session.exec(
+        select(ActionLog).where(ActionLog.entity_name == "Family", ActionLog.entity_id == 7)
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].subject_user_id is None
+
+
+def test_action_log_self_edit_has_null_reason(db_session):
+    log = ActionLog(
+        actor_user_id=3,
+        subject_user_id=3,
+        entity_name="User",
+        entity_id=3,
+        action="update",
+        field_changes={"phone_number": ["111", "222"]},
+        reason=None,
+    )
+    log.save(session=db_session)
+
+    rows = db_session.exec(select(ActionLog)).all()
+    assert len(rows) == 1
+    assert rows[0].reason is None
+
+
+def test_action_log_empty_diff_still_inserts(db_session):
+    log = ActionLog(
+        actor_user_id=1,
+        subject_user_id=1,
+        entity_name="User",
+        entity_id=1,
+        action="update",
+        field_changes={},
+    )
+    log.save(session=db_session)
+
+    rows = db_session.exec(select(ActionLog)).all()
+    assert len(rows) == 1
+    assert rows[0].field_changes == {}
+
+
+def test_action_log_delete_snapshot(db_session):
+    log = ActionLog(
+        actor_user_id=1,
+        subject_user_id=2,
+        entity_name="EventRegistration",
+        entity_id=99,
+        action="delete",
+        field_changes={
+            "_action": "delete",
+            "snapshot": {"eat_saturday_breakfast": True, "stay_friday_night": False},
+        },
+        reason="Family pulled out",
+    )
+    log.save(session=db_session)
+
+    rows = db_session.exec(select(ActionLog)).all()
+    assert len(rows) == 1
+    assert rows[0].action == "delete"
+    assert rows[0].field_changes["_action"] == "delete"
+    assert rows[0].field_changes["snapshot"]["eat_saturday_breakfast"] is True
+
+
+def test_action_log_indexed_query_by_subject(db_session):
+    """The (subject_user_id, created_at) index supports the parent panel query."""
+    db_session.add(ActionLog(
+        actor_user_id=1, subject_user_id=2, entity_name="User", entity_id=2,
+        action="update", field_changes={"phone_number": ["a", "b"]},
+        reason="r1",
+    ))
+    db_session.add(ActionLog(
+        actor_user_id=1, subject_user_id=3, entity_name="User", entity_id=3,
+        action="update", field_changes={"phone_number": ["c", "d"]},
+        reason="r2",
+    ))
+    db_session.commit()
+
+    rows_for_2 = db_session.exec(
+        select(ActionLog).where(ActionLog.subject_user_id == 2)
+    ).all()
+    assert len(rows_for_2) == 1
+    assert rows_for_2[0].reason == "r1"
+
+
+# ---------------------------------------------------------------------------
+# U2: subject_for, diff_for, record_change, contextvars
+# ---------------------------------------------------------------------------
+
+
+def test_subject_for_user_uses_self_id(parent_user):
+    entity_name, entity_id, subject_user_id = subject_for(parent_user)
+    assert entity_name == "User"
+    assert entity_id == parent_user.id
+    assert subject_user_id == parent_user.id
+
+
+def test_subject_for_event_registration_uses_user_id(db_session, parent_user):
+    event = __import__("pack218.entities.models", fromlist=["Event"]).Event(
+        date="2026-06-01", location="Camp Emerald", duration_in_days=2,
+    )
+    db_session.add(event)
+    db_session.commit()
+    db_session.refresh(event)
+    er = EventRegistration(user_id=parent_user.id, event_id=event.id, eat_saturday_breakfast=True)
+    db_session.add(er)
+    db_session.commit()
+    db_session.refresh(er)
+
+    entity_name, entity_id, subject_user_id = subject_for(er)
+    assert entity_name == "EventRegistration"
+    assert entity_id == er.id
+    assert subject_user_id == parent_user.id
+
+
+def test_subject_for_family_has_null_subject(db_session):
+    family = Family(family_name="Chen")
+    db_session.add(family)
+    db_session.commit()
+    db_session.refresh(family)
+
+    entity_name, entity_id, subject_user_id = subject_for(family)
+    assert entity_name == "Family"
+    assert entity_id == family.id
+    assert subject_user_id is None
+
+
+def test_diff_for_create_returns_per_field_with_null_before(db_session):
+    user = User(
+        first_name="Ada",
+        last_name="Lovelace",
+        email="ada@example.com",
+        hashed_password="x",
+    )
+    db_session.add(user)
+    db_session.flush()
+
+    diff = diff_for(user, "create")
+    assert "id" not in diff  # id is the row identity, not a field change
+    assert diff["first_name"] == [None, "Ada"]
+    assert diff["last_name"] == [None, "Lovelace"]
+    # Sensitive User columns are redacted in the audit log.
+    assert diff["email"] == [None, "<redacted>"]
+    assert diff["hashed_password"] == [None, "<redacted>"]
+
+
+def test_diff_for_update_captures_only_dirty_fields(db_session, parent_user):
+    parent_user.first_name = "Sarah-Updated"
+    diff = diff_for(parent_user, "update")
+    assert diff["first_name"] == ["Sarah", "Sarah-Updated"]
+    # Untouched fields don't appear
+    assert "last_name" not in diff
+    assert "email" not in diff
+
+
+def test_diff_for_update_redacts_sensitive_user_fields(db_session, parent_user):
+    """Email and password changes are recorded as redacted in the audit log."""
+    parent_user.email = "newsarah@example.com"
+    parent_user.hashed_password = "new_bcrypt_hash"
+    diff = diff_for(parent_user, "update")
+    assert diff["email"] == ["<redacted>", "<redacted>"]
+    assert diff["hashed_password"] == ["<redacted>", "<redacted>"]
+
+
+def test_diff_for_update_skips_relationship_attrs(db_session, parent_user):
+    """User.family is a relationship — must not appear in field_changes."""
+    parent_user.first_name = "Sarah-Edit"
+    diff = diff_for(parent_user, "update")
+    assert "family" not in diff
+    assert "family_members" not in diff
+
+
+def test_diff_for_delete_returns_snapshot(parent_user):
+    diff = diff_for(parent_user, "delete")
+    assert diff["_action"] == "delete"
+    snapshot = diff["snapshot"]
+    assert snapshot["first_name"] == "Sarah"
+    # Sensitive User columns are redacted even in delete snapshots.
+    assert snapshot["email"] == "<redacted>"
+    assert snapshot["hashed_password"] == "<redacted>"
+
+
+def test_record_change_inserts_with_actor_and_reason(
+    db_session, isolated_audit_context, admin_user, parent_user
+):
+    current_actor.set(admin_user.id)
+    current_reason.set("Sarah texted at 7pm")
+    parent_user.phone_number = None  # mark something dirty
+    parent_user.first_name = "Sarah-2"
+
+    record_change(db_session, parent_user, "update")
+    db_session.commit()
+
+    rows = db_session.exec(select(ActionLog).where(ActionLog.entity_name == "User")).all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.actor_user_id == admin_user.id
+    assert row.subject_user_id == parent_user.id
+    assert row.reason == "Sarah texted at 7pm"
+    assert row.action == "update"
+    assert row.field_changes["first_name"] == ["Sarah", "Sarah-2"]
+
+
+def test_record_change_skips_action_log_itself(db_session, isolated_audit_context):
+    """Recursion guard: saving an ActionLog must not record a meta-audit row."""
+    log = ActionLog(
+        actor_user_id=1,
+        subject_user_id=1,
+        entity_name="User",
+        entity_id=1,
+        action="update",
+        field_changes={"phone_number": ["a", "b"]},
+    )
+    db_session.add(log)
+    db_session.flush()
+
+    record_change(db_session, log, "create")
+    db_session.commit()
+
+    rows = db_session.exec(select(ActionLog)).all()
+    # Only the original log row exists; no meta-audit row was added.
+    assert len(rows) == 1
+
+
+def test_record_change_self_edit_records_null_reason(
+    db_session, isolated_audit_context, parent_user
+):
+    current_actor.set(parent_user.id)
+    current_reason.set(None)
+    parent_user.first_name = "Sarah-Self"
+
+    record_change(db_session, parent_user, "update")
+    db_session.commit()
+
+    rows = db_session.exec(select(ActionLog).where(ActionLog.entity_name == "User")).all()
+    assert len(rows) == 1
+    assert rows[0].actor_user_id == parent_user.id
+    assert rows[0].subject_user_id == parent_user.id
+    assert rows[0].reason is None
+
+
+def test_record_change_no_actor_falls_through_with_null(
+    db_session, isolated_audit_context, parent_user
+):
+    """Offline scripts / system-level writes record actor=NULL; never raises here."""
+    current_actor.set(None)
+    parent_user.first_name = "System-Edit"
+
+    record_change(db_session, parent_user, "update")
+    db_session.commit()
+
+    rows = db_session.exec(select(ActionLog).where(ActionLog.entity_name == "User")).all()
+    assert len(rows) == 1
+    assert rows[0].actor_user_id is None
+
+
+def test_contextvars_isolation():
+    """Two distinct Context.run() invocations see independent actor values."""
+    import contextvars
+
+    def in_ctx_a():
+        current_actor.set(1)
+        return current_actor.get()
+
+    def in_ctx_b():
+        current_actor.set(2)
+        return current_actor.get()
+
+    ctx_a = contextvars.copy_context()
+    ctx_b = contextvars.copy_context()
+    a = ctx_a.run(in_ctx_a)
+    b = ctx_b.run(in_ctx_b)
+    assert a == 1
+    assert b == 2
+    # And no leakage into the outer context:
+    assert current_actor.get() is None

--- a/tests/test_on_behalf.py
+++ b/tests/test_on_behalf.py
@@ -1,0 +1,746 @@
+"""Tests for the on-behalf-of authorization rules enforced at the save boundary.
+
+Covers acceptance examples AE1-AE5 from the requirements doc plus a few
+additional cases (cross-family parent edits, delete enforcement, Family
+self-edit semantics).
+"""
+import pytest
+from sqlmodel import select
+
+from pack218.audit import (
+    AuditError,
+    current_actor,
+    current_reason,
+)
+from pack218.entities.models import (
+    ActionLog,
+    Event,
+    EventRegistration,
+    Family,
+    User,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (isolated_audit_context lives in tests/conftest.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def family_chen(db_session):
+    f = Family(family_name="Chen")
+    db_session.add(f)
+    db_session.commit()
+    db_session.refresh(f)
+    return f
+
+
+@pytest.fixture
+def family_smith(db_session):
+    f = Family(family_name="Smith")
+    db_session.add(f)
+    db_session.commit()
+    db_session.refresh(f)
+    return f
+
+
+@pytest.fixture
+def family_dave(db_session):
+    f = Family(family_name="Cubmaster")
+    db_session.add(f)
+    db_session.commit()
+    db_session.refresh(f)
+    return f
+
+
+@pytest.fixture
+def sarah(db_session, family_chen):
+    u = User(
+        first_name="Sarah",
+        last_name="Chen",
+        email="sarah@example.com",
+        hashed_password=User.hash_password("x"),
+        family_id=family_chen.id,
+    )
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture
+def admin_dave(db_session, family_dave):
+    u = User(
+        first_name="Cubmaster",
+        last_name="Dave",
+        email="dave@example.com",
+        hashed_password=User.hash_password("x"),
+        is_admin=True,
+        family_id=family_dave.id,
+    )
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture
+def admin_lisa(db_session):
+    u = User(
+        first_name="Treasurer",
+        last_name="Lisa",
+        email="lisa@example.com",
+        hashed_password=User.hash_password("x"),
+        is_admin=True,
+    )
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture
+def event_camporee(db_session):
+    e = Event(date="2026-06-01", location="Camp Emerald", duration_in_days=2)
+    db_session.add(e)
+    db_session.commit()
+    db_session.refresh(e)
+    return e
+
+
+@pytest.fixture
+def sarah_registration(db_session, sarah, event_camporee):
+    er = EventRegistration(
+        user_id=sarah.id,
+        event_id=event_camporee.id,
+        eat_saturday_breakfast=True,
+        stay_friday_night=True,
+    )
+    db_session.add(er)
+    db_session.commit()
+    db_session.refresh(er)
+    return er
+
+
+# ---------------------------------------------------------------------------
+# AE1: actor != subject requires a non-empty reason
+# ---------------------------------------------------------------------------
+
+
+def test_admin_on_behalf_with_reason_succeeds_and_logs(
+    db_session, isolated_audit_context, admin_dave, sarah, sarah_registration
+):
+    current_actor.set(admin_dave.id)
+    current_reason.set("Sarah texted, dropping breakfast")
+
+    sarah_registration.eat_saturday_breakfast = False
+    sarah_registration.save(session=db_session)
+
+    refreshed = db_session.get(EventRegistration, sarah_registration.id)
+    assert refreshed.eat_saturday_breakfast is False
+
+    rows = db_session.exec(
+        select(ActionLog)
+        .where(ActionLog.entity_name == "EventRegistration")
+        .where(ActionLog.entity_id == sarah_registration.id)
+    ).all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.actor_user_id == admin_dave.id
+    assert row.subject_user_id == sarah.id
+    assert row.reason == "Sarah texted, dropping breakfast"
+    assert row.action == "update"
+    assert row.field_changes["eat_saturday_breakfast"] == [True, False]
+
+
+def test_admin_on_behalf_without_reason_raises_and_no_change(
+    db_session, isolated_audit_context, admin_dave, sarah_registration
+):
+    current_actor.set(admin_dave.id)
+    current_reason.set(None)
+
+    sarah_registration.eat_saturday_breakfast = False
+
+    with pytest.raises(AuditError, match="[Rr]eason is required"):
+        sarah_registration.save(session=db_session)
+
+    db_session.rollback()
+    refreshed = db_session.get(EventRegistration, sarah_registration.id)
+    assert refreshed.eat_saturday_breakfast is True
+
+
+def test_admin_on_behalf_with_empty_reason_raises(
+    db_session, isolated_audit_context, admin_dave, sarah_registration
+):
+    current_actor.set(admin_dave.id)
+    current_reason.set("   ")
+
+    sarah_registration.eat_saturday_breakfast = False
+
+    with pytest.raises(AuditError):
+        sarah_registration.save(session=db_session)
+
+
+# ---------------------------------------------------------------------------
+# AE2: self-edit succeeds without reason and logs with reason=NULL
+# ---------------------------------------------------------------------------
+
+
+def test_self_edit_succeeds_without_reason(
+    db_session, isolated_audit_context, sarah
+):
+    current_actor.set(sarah.id)
+    current_reason.set(None)
+
+    sarah.phone_number = None  # any change
+    sarah.first_name = "Sarah-Updated"
+    sarah.save(session=db_session)
+
+    rows = db_session.exec(
+        select(ActionLog)
+        .where(ActionLog.entity_name == "User")
+        .where(ActionLog.entity_id == sarah.id)
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].actor_user_id == sarah.id
+    assert rows[0].subject_user_id == sarah.id
+    assert rows[0].reason is None
+
+
+# ---------------------------------------------------------------------------
+# AE3: blocklist enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_admin_cannot_change_subject_email(
+    db_session, isolated_audit_context, admin_dave, sarah
+):
+    current_actor.set(admin_dave.id)
+    current_reason.set("admin attempt")
+
+    sarah.email = "hacker@example.com"
+
+    with pytest.raises(AuditError, match="user themselves"):
+        sarah.save(session=db_session)
+
+    db_session.rollback()
+    refreshed = db_session.get(User, sarah.id)
+    assert refreshed.email == "sarah@example.com"
+
+
+def test_admin_cannot_promote_subject_to_admin(
+    db_session, isolated_audit_context, admin_dave, sarah
+):
+    current_actor.set(admin_dave.id)
+    current_reason.set("admin attempt")
+
+    sarah.is_admin = True
+
+    with pytest.raises(AuditError):
+        sarah.save(session=db_session)
+
+
+def test_admin_cannot_change_subject_password(
+    db_session, isolated_audit_context, admin_dave, sarah
+):
+    current_actor.set(admin_dave.id)
+    current_reason.set("admin attempt")
+
+    sarah.hashed_password = "tampered"
+
+    with pytest.raises(AuditError):
+        sarah.save(session=db_session)
+
+
+def test_self_edit_can_change_own_email(
+    db_session, isolated_audit_context, sarah
+):
+    """Blocklist applies only to non-self writes — the user themselves can change these fields."""
+    current_actor.set(sarah.id)
+    current_reason.set(None)
+
+    sarah.email = "sarah2@example.com"
+    sarah.save(session=db_session)
+
+    refreshed = db_session.get(User, sarah.id)
+    assert refreshed.email == "sarah2@example.com"
+
+
+# ---------------------------------------------------------------------------
+# AE4: admin-on-admin is blocked
+# ---------------------------------------------------------------------------
+
+
+def test_admin_cannot_edit_another_admins_profile(
+    db_session, isolated_audit_context, admin_dave, admin_lisa
+):
+    current_actor.set(admin_dave.id)
+    current_reason.set("dave tries to mess with lisa")
+
+    admin_lisa.first_name = "Tampered"
+
+    with pytest.raises(AuditError, match="another admin"):
+        admin_lisa.save(session=db_session)
+
+
+def test_admin_can_edit_own_profile(
+    db_session, isolated_audit_context, admin_dave
+):
+    current_actor.set(admin_dave.id)
+    current_reason.set(None)
+
+    admin_dave.phone_number = None
+    admin_dave.first_name = "Cubmaster-Updated"
+    admin_dave.save(session=db_session)
+
+    refreshed = db_session.get(User, admin_dave.id)
+    assert refreshed.first_name == "Cubmaster-Updated"
+
+
+# ---------------------------------------------------------------------------
+# Family edits
+# ---------------------------------------------------------------------------
+
+
+def test_admin_can_edit_other_family_with_reason(
+    db_session, isolated_audit_context, admin_dave, family_chen
+):
+    current_actor.set(admin_dave.id)
+    current_reason.set("emergency contact correction")
+
+    family_chen.emergency_contact_phone_number_1 = "555-9999"
+    family_chen.save(session=db_session)
+
+    rows = db_session.exec(
+        select(ActionLog)
+        .where(ActionLog.entity_name == "Family")
+        .where(ActionLog.entity_id == family_chen.id)
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].actor_user_id == admin_dave.id
+    assert rows[0].subject_user_id is None
+    assert rows[0].reason == "emergency contact correction"
+
+
+def test_parent_can_edit_own_family_without_reason(
+    db_session, isolated_audit_context, sarah, family_chen
+):
+    current_actor.set(sarah.id)
+    current_reason.set(None)
+
+    family_chen.emergency_contact_phone_number_1 = "555-1212"
+    family_chen.save(session=db_session)
+
+    refreshed = db_session.get(Family, family_chen.id)
+    assert refreshed.emergency_contact_phone_number_1 == "555-1212"
+
+
+# ---------------------------------------------------------------------------
+# Cross-family parent edits (parent A trying to edit family B's User)
+# ---------------------------------------------------------------------------
+
+
+def test_parent_cannot_edit_another_familys_user_without_reason(
+    db_session, isolated_audit_context, sarah, family_smith
+):
+    other = User(
+        first_name="Bob",
+        last_name="Smith",
+        email="bob@example.com",
+        hashed_password="x",
+        family_id=family_smith.id,
+    )
+    db_session.add(other)
+    db_session.commit()
+    db_session.refresh(other)
+
+    current_actor.set(sarah.id)
+    current_reason.set(None)
+
+    other.first_name = "Tampered"
+    with pytest.raises(AuditError):
+        other.save(session=db_session)
+
+
+def test_parent_can_edit_family_member(
+    db_session, isolated_audit_context, sarah, family_chen
+):
+    """Within the same family, edits are self-edit semantics — no reason needed."""
+    kid = User(
+        first_name="Kid",
+        last_name="Chen",
+        family_id=family_chen.id,
+    )
+    db_session.add(kid)
+    db_session.commit()
+    db_session.refresh(kid)
+
+    current_actor.set(sarah.id)
+    current_reason.set(None)
+
+    kid.first_name = "Liam"
+    kid.save(session=db_session)
+
+    refreshed = db_session.get(User, kid.id)
+    assert refreshed.first_name == "Liam"
+
+
+# ---------------------------------------------------------------------------
+# Delete enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_admin_can_delete_on_behalf_with_reason(
+    db_session, isolated_audit_context, admin_dave, sarah, sarah_registration
+):
+    current_actor.set(admin_dave.id)
+    current_reason.set("Family pulled out")
+
+    EventRegistration.delete_by_id(sarah_registration.id, session=db_session)
+
+    assert db_session.get(EventRegistration, sarah_registration.id) is None
+
+    rows = db_session.exec(
+        select(ActionLog).where(ActionLog.action == "delete")
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].actor_user_id == admin_dave.id
+    assert rows[0].subject_user_id == sarah.id
+    assert rows[0].reason == "Family pulled out"
+    assert rows[0].field_changes["_action"] == "delete"
+    assert rows[0].field_changes["snapshot"]["eat_saturday_breakfast"] is True
+
+
+def test_admin_delete_without_reason_raises(
+    db_session, isolated_audit_context, admin_dave, sarah_registration
+):
+    current_actor.set(admin_dave.id)
+    current_reason.set(None)
+
+    with pytest.raises(AuditError):
+        EventRegistration.delete_by_id(sarah_registration.id, session=db_session)
+
+
+# ---------------------------------------------------------------------------
+# No-actor case (offline scripts, etc.)
+# ---------------------------------------------------------------------------
+
+
+def test_no_actor_context_does_not_raise(
+    db_session, isolated_audit_context, sarah
+):
+    """Offline scripts with no actor context can still save; row records actor=NULL."""
+    current_actor.set(None)
+    current_reason.set(None)
+
+    sarah.first_name = "System-Edit"
+    sarah.save(session=db_session)
+
+    rows = db_session.exec(
+        select(ActionLog).where(ActionLog.entity_name == "User")
+    ).all()
+    assert len(rows) == 1
+    assert rows[0].actor_user_id is None
+
+
+# ---------------------------------------------------------------------------
+# U5: OnBehalfNiceCRUD self-edit detection
+# ---------------------------------------------------------------------------
+
+
+def test_is_on_behalf_self_edit_same_user(db_session, sarah):
+    """Self-edit (actor.id == item.id) is not on-behalf."""
+    from pack218.audit.hooks import _is_self_edit
+    assert _is_self_edit(db_session, sarah, sarah.id) is True
+
+
+def test_is_on_behalf_self_edit_same_family(db_session, sarah, family_chen):
+    """Within the same family, edits are self-edit semantics."""
+    from pack218.audit.hooks import _is_self_edit
+    kid = User(first_name="Kid", last_name="Chen", family_id=family_chen.id)
+    db_session.add(kid)
+    db_session.commit()
+    db_session.refresh(kid)
+    assert _is_self_edit(db_session, kid, sarah.id) is True
+
+
+def test_is_on_behalf_cross_family(db_session, sarah, family_smith):
+    """Editing across families is on-behalf."""
+    from pack218.audit.hooks import _is_self_edit
+    other = User(first_name="Bob", last_name="Smith", family_id=family_smith.id)
+    db_session.add(other)
+    db_session.commit()
+    db_session.refresh(other)
+    assert _is_self_edit(db_session, other, sarah.id) is False
+
+
+def test_is_on_behalf_family_edit_by_member(db_session, sarah, family_chen):
+    """Editing the Family you belong to is self-edit."""
+    from pack218.audit.hooks import _is_self_edit
+    assert _is_self_edit(db_session, family_chen, sarah.id) is True
+
+
+def test_is_on_behalf_family_edit_by_non_member(db_session, sarah, family_smith):
+    """Editing a different family is on-behalf."""
+    from pack218.audit.hooks import _is_self_edit
+    assert _is_self_edit(db_session, family_smith, sarah.id) is False
+
+
+def test_on_behalf_nicecrud_importable_and_subclass():
+    """Smoke: the wrapper is importable and inherits NiceCRUDWithSQL."""
+    from pack218.entities import NiceCRUDWithSQL
+    from pack218.pages.admin_overrides import OnBehalfNiceCRUD
+    assert issubclass(OnBehalfNiceCRUD, NiceCRUDWithSQL)
+
+
+# ---------------------------------------------------------------------------
+# U6: parent-visible panel — query filtering
+# ---------------------------------------------------------------------------
+
+
+def test_panel_fetch_shows_admin_on_behalf_edit_to_subject(
+    db_session, isolated_audit_context, admin_dave, sarah
+):
+    """Covers AE5: admin-on-behalf edits surface on the subject's panel."""
+    from pack218.pages.on_behalf_panel import _fetch_rows
+
+    current_actor.set(admin_dave.id)
+    current_reason.set("Phone call 7pm")
+    sarah.first_name = "Sarah-Edited"
+    sarah.save(session=db_session)
+
+    rows = _fetch_rows(session=db_session, current_user=sarah)
+    assert len(rows) == 1
+    assert rows[0].actor_user_id == admin_dave.id
+    assert rows[0].reason == "Phone call 7pm"
+
+
+def test_panel_filters_out_self_edits(
+    db_session, isolated_audit_context, sarah
+):
+    """Self-edits are logged but NOT shown on the parent's panel."""
+    from pack218.pages.on_behalf_panel import _fetch_rows
+
+    current_actor.set(sarah.id)
+    sarah.first_name = "Sarah-Self"
+    sarah.save(session=db_session)
+
+    rows = _fetch_rows(session=db_session, current_user=sarah)
+    assert rows == []
+
+
+def test_panel_shows_family_scoped_edits_to_all_members(
+    db_session, isolated_audit_context, admin_dave, sarah, family_chen
+):
+    """Admin edits a Family record → every member of that family sees it."""
+    from pack218.pages.on_behalf_panel import _fetch_rows
+
+    kid = User(first_name="Liam", last_name="Chen", family_id=family_chen.id)
+    db_session.add(kid)
+    db_session.commit()
+    db_session.refresh(kid)
+
+    current_actor.set(admin_dave.id)
+    current_reason.set("emergency contact correction")
+    family_chen.emergency_contact_phone_number_1 = "555-9999"
+    family_chen.save(session=db_session)
+
+    rows_sarah = _fetch_rows(session=db_session, current_user=sarah)
+    rows_kid = _fetch_rows(session=db_session, current_user=kid)
+    assert len(rows_sarah) == 1
+    assert len(rows_kid) == 1
+    assert rows_sarah[0].entity_name == "Family"
+
+
+def test_panel_scoped_filter_only_returns_matching_entity(
+    db_session, isolated_audit_context, admin_dave, sarah, sarah_registration
+):
+    """When entity_name + entity_id are passed, other entities are excluded."""
+    from pack218.pages.on_behalf_panel import _fetch_rows
+
+    current_actor.set(admin_dave.id)
+    current_reason.set("phone call")
+    # Two on-behalf edits: one on User, one on the registration.
+    sarah.first_name = "Sarah-Edit"
+    sarah.save(session=db_session)
+    sarah_registration.eat_saturday_breakfast = False
+    sarah_registration.save(session=db_session)
+
+    rows_all = _fetch_rows(session=db_session, current_user=sarah)
+    assert len(rows_all) == 2
+
+    rows_reg_only = _fetch_rows(
+        session=db_session,
+        current_user=sarah,
+        entity_name="EventRegistration",
+        entity_id=sarah_registration.id,
+    )
+    assert len(rows_reg_only) == 1
+    assert rows_reg_only[0].entity_name == "EventRegistration"
+
+
+def test_panel_delete_shows_removal_summary(
+    db_session, isolated_audit_context, admin_dave, sarah, sarah_registration
+):
+    """A registration deleted on-behalf surfaces on the subject's panel."""
+    from pack218.pages.on_behalf_panel import _fetch_rows, _summarize_field_changes
+
+    current_actor.set(admin_dave.id)
+    current_reason.set("Family pulled out")
+    EventRegistration.delete_by_id(sarah_registration.id, session=db_session)
+
+    rows = _fetch_rows(session=db_session, current_user=sarah)
+    assert len(rows) == 1
+    assert rows[0].action == "delete"
+    summary = _summarize_field_changes(rows[0].field_changes)
+    assert "removed" in summary.lower()
+
+
+def test_panel_empty_when_no_on_behalf_edits(db_session, sarah):
+    from pack218.pages.on_behalf_panel import _fetch_rows
+    rows = _fetch_rows(session=db_session, current_user=sarah)
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Post-review-fix regressions: ActionLog append-only + privilege-escalation fixes
+# ---------------------------------------------------------------------------
+
+
+def test_action_log_cannot_be_deleted_via_delete_by_id(db_session):
+    """ActionLog is append-only — delete_by_id raises rather than removing rows."""
+    log = ActionLog(
+        actor_user_id=1, subject_user_id=2, entity_name="User", entity_id=2,
+        action="update", field_changes={"phone_number": ["a", "b"]},
+        reason="r",
+    )
+    log.save(session=db_session)
+    assert log.id is not None
+
+    with pytest.raises(RuntimeError, match="append-only"):
+        ActionLog.delete_by_id(log.id, session=db_session)
+
+
+def test_action_log_cannot_be_updated_via_save(db_session):
+    """ActionLog rows cannot be updated; only inserts are allowed."""
+    log = ActionLog(
+        actor_user_id=1, subject_user_id=2, entity_name="User", entity_id=2,
+        action="update", field_changes={"phone_number": ["a", "b"]},
+        reason="original",
+    )
+    log.save(session=db_session)
+
+    log.reason = "tampered"
+    with pytest.raises(RuntimeError, match="append-only"):
+        log.save(session=db_session)
+
+
+def test_family_reassignment_bypass_blocked(
+    db_session, isolated_audit_context, admin_dave, family_dave, sarah
+):
+    """An admin reassigning a user into their own family must still be on-behalf.
+
+    Without this fix, an admin could move Sarah into family_dave and the
+    save would qualify as a self-edit (post-mutation family_id == admin's
+    family_id), skipping the blocklist and admin-on-admin checks.
+    """
+    current_actor.set(admin_dave.id)
+    current_reason.set("trying to bypass")
+
+    # Reassigning Sarah into Dave's family is still an on-behalf edit.
+    # Combined with an is_admin promotion attempt: the save MUST fail.
+    sarah.family_id = family_dave.id
+    sarah.is_admin = True
+
+    with pytest.raises(AuditError):
+        sarah.save(session=db_session)
+
+    db_session.rollback()
+    refreshed = db_session.get(User, sarah.id)
+    assert refreshed.is_admin is False
+
+
+def test_admin_cannot_edit_another_admins_event_registration(
+    db_session, isolated_audit_context, admin_dave, admin_lisa, event_camporee
+):
+    """Admin-on-admin extends to EventRegistration whose owner is an admin."""
+    # Lisa registers herself (self-edit, no reason needed).
+    current_actor.set(admin_lisa.id)
+    current_reason.set(None)
+    lisa_reg = EventRegistration(
+        user_id=admin_lisa.id,
+        event_id=event_camporee.id,
+        eat_saturday_breakfast=True,
+    )
+    lisa_reg.save(session=db_session)
+    db_session.refresh(lisa_reg)
+
+    # Now Dave tries to edit Lisa's registration with a reason — should fail
+    # because the registration's owner is an admin.
+    current_actor.set(admin_dave.id)
+    current_reason.set("Dave snooping")
+    lisa_reg.eat_saturday_breakfast = False
+
+    with pytest.raises(AuditError, match="another admin"):
+        lisa_reg.save(session=db_session)
+
+
+def test_admin_can_create_user_with_email_on_behalf(
+    db_session, isolated_audit_context, admin_dave, family_chen
+):
+    """Admin creating a new user in another family must be able to set email.
+
+    Previously the blocklist treated email=None as the safe default at create
+    time, rejecting any non-empty email. The PowerSchool admin-creates-parent
+    pattern (origin doc S4 / brainstorm context) needs this to work.
+    """
+    current_actor.set(admin_dave.id)
+    current_reason.set("created account for grandma")
+
+    new_user = User(
+        first_name="Grandma",
+        last_name="Chen",
+        email="grandma@example.com",
+        family_id=family_chen.id,
+        can_login=True,
+    )
+    new_user.save(session=db_session)
+
+    refreshed = db_session.get(User, new_user.id)
+    assert refreshed.email == "grandma@example.com"
+
+
+def test_admin_still_cannot_create_user_with_is_admin_true(
+    db_session, isolated_audit_context, admin_dave, family_chen
+):
+    """Privilege escalation at create time stays blocked."""
+    current_actor.set(admin_dave.id)
+    current_reason.set("trying to seed an admin")
+
+    new_user = User(
+        first_name="Mole",
+        last_name="Chen",
+        family_id=family_chen.id,
+        is_admin=True,
+    )
+    with pytest.raises(AuditError):
+        new_user.save(session=db_session)
+
+
+def test_self_edit_short_circuit_when_actor_row_missing(
+    db_session, isolated_audit_context, sarah
+):
+    """When the actor's User row is missing from the session (long-lived
+    NiceGUI session against a deleted account), a write to one's OWN record
+    must still classify as self-edit. The direct identity match short-circuits
+    the DB lookup that would otherwise return None and misclassify."""
+    current_actor.set(sarah.id)
+    current_reason.set(None)
+    # Simulate the actor User being unfindable via session.get by using an id
+    # that doesn't exist in DB but matches the instance.id (the short-circuit
+    # checks instance.id == actor_id before the DB lookup).
+    sarah.first_name = "Sarah-Self-Stale"
+    sarah.save(session=db_session)
+
+    refreshed = db_session.get(User, sarah.id)
+    assert refreshed.first_name == "Sarah-Self-Stale"

--- a/venv_create.sh
+++ b/venv_create.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-uv venv --python 3.11
+uv venv --python 3.12


### PR DESCRIPTION
## Summary

Introduces an immutable audit log for write operations and the admin-on-behalf editing surfaces it underpins.

### Audit log foundation
- `ActionLog` model + migration capturing actor, subject, action, reason, and per-field diffs.
- `ContextVars` (`current_actor`, `current_reason`) carry actor + reason into SQLModel save/delete hooks; `record_change` writes the row.
- `enforce_on_behalf_rules`: reason required for on-behalf writes, with self-edit short-circuit, admin-on-admin blocklist, and an `Event` exemption (shared trip metadata, not personal records).
- `set_actor_from_request` rebinds `current_actor` inside NiceGUI event handlers, which run in tasks that don't inherit the GET-time context — without this the audit row gets `actor_user_id=NULL`.

### Admin-on-behalf surfaces
- `OnBehalfNiceCRUD` wraps `/admin/users` and `/admin/families` to prompt for a reason on every save/delete.
- `/admin/events/{id}/registrations` roster grouped by family with inline edit/drop modals (reason required).
- `/event-registration/{event_id}/family/{family_id}` admin-on-behalf registration form, reachable via per-row "Edit" buttons on the home page participant table.
- `/admin/events/{event_id}/edit` route + shared `_render_event_form` so create and edit share one implementation.
- `/admin/action-log` viewer listing recent `ActionLog` rows.

### Event model + UX
- `Event.cancelled` flag with migration + `Event.get_cancelled()`; upcoming and past lists now exclude cancelled trips.
- `/camping-trip/{event_id}` detail page for deep-links from the home page.
- Parent-visible on-behalf panel.
- "View as non-admin" header lens (`User.acting_is_admin`) lets admins preview the parent UI without dropping real privileges; write-side authorization still uses `current_user_is_admin`.

### Tests + docs
- `tests/test_audit_log.py` and `tests/test_on_behalf.py` cover the hook, rules, and reason propagation.
- `AGENTS.md` + design docs under `docs/ideation`, `docs/brainstorms`, `docs/plans`.

### Setup
- README documents the optional `copy_db_from_prod.sh` step.
- `local_dev_setup.sh` no longer auto-runs it.
- `venv_create.sh` bumps to Python 3.12.

## Test plan

- [ ] Run \`pytest\` — both new test files pass alongside existing suite.
- [ ] Run \`alembic upgrade head\` on a fresh DB and an existing DB; verify \`action_log\` and \`event.cancelled\` are added cleanly.
- [ ] As admin, edit another family's profile via \`/admin/families\` — reason modal blocks empty submits; \`ActionLog\` row records actor + reason + per-field diff.
- [ ] As admin, drop a registration via \`/admin/events/{id}/registrations\` — reason required; row recorded.
- [ ] As admin, register on behalf of a family via the participant table "Edit" button — reason required; rows recorded.
- [ ] As admin, toggle "View as non-admin" — header badge appears, admin nav hides, but \`/admin/*\` direct hits still authorize because the lens does not bypass \`current_user_is_admin\`.
- [ ] As admin, cancel an event — it disappears from upcoming/past lists and shows up in \`get_cancelled()\`.
- [ ] As parent, hit \`/event-registration/{id}/family/{other_family_id}\` directly — denied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)