### PR TITLE
fix(app): install SessionMiddleware on nicegui.app, not fastapi_app

### DIFF
--- a/pack218/app.py
+++ b/pack218/app.py
@@ -68,8 +68,13 @@ async def lifespan(app_: FastAPI):
     logger.info("Shutting down...")
 
 fastapi_app = FastAPI(lifespan=lifespan, docs_url=None, redoc_url=None)
-fastapi_app.add_middleware(SessionMiddleware, secret_key=config.pack218_storage_key)
-fastapi_app.add_middleware(
+# NOTE: Routes are registered on nicegui's `app` (e.g. @app.get('/login')) and
+# uvicorn launches `pack218.app:app` (= nicegui.app), so requests bypass
+# `fastapi_app` entirely. Middlewares must live on nicegui.app to be in scope
+# for the OAuth handlers and nicegui's RequestTrackingMiddleware, which
+# requires SessionMiddleware to be installed before it runs.
+app.add_middleware(SessionMiddleware, secret_key=config.pack218_storage_key)
+app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"], #replace where needed
     allow_methods=["*"],


### PR DESCRIPTION
## Summary

- Prod was returning HTTP 500 on every request with `AssertionError: SessionMiddleware must be installed to access request.session`, raised from nicegui's `RequestTrackingMiddleware`.
- The Dockerfile launches `pack218.app:app`, and `app` in `pack218/app.py` is bound to `nicegui.app` (via `from nicegui import ui, app`). Requests therefore hit nicegui's core app directly and bypass `fastapi_app`. The previous `fastapi_app.add_middleware(SessionMiddleware, ...)` was dead code.
- Moved `SessionMiddleware` and `CORSMiddleware` onto `nicegui.app` so they actually run. Installing `SessionMiddleware` before `ui.run_with(...)` also lets nicegui's `set_storage_secret` detect it and append `RequestTrackingMiddleware` in the correct order (Session must populate `scope["session"]` before RTM reads it).

## Test plan

- [x] Boot uvicorn against `pack218.app:app` locally.
- [x] Hit `/login` → `/my-profile` → `/`; all 200 OK, session cookie round-trips.
- [x] Inspect `nicegui.app.user_middleware` after import: order is `SetCacheControl → Redirect → GZip → CORS → Session → RequestTracking`.
- [ ] Deploy to prod and confirm the assertion error is gone. Re-run `pip install -r requirements.txt` on prod when deploying, since `main` bumped nicegui 2.11.1 → 3.7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)