### PR TITLE
feat(events): rich-text editor + image upload for event details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ client_secret_*
 credentials.json
 
 copy_db_from_prod.sh
+
+pack218/images/uploads/

--- a/pack218/app.py
+++ b/pack218/app.py
@@ -5,7 +5,7 @@ use the great `Authlib package <https://docs.authlib.org/en/v0.13/client/starlet
 Here we just demonstrate the NiceGUI integration.
 """
 from authlib.integrations.starlette_client import OAuth
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI, Depends, UploadFile, File
 from fastapi.security import OAuth2PasswordBearer
 from jose import jwt
 from nicegui import ui
@@ -14,8 +14,11 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse
+import json
 import logging
 import os
+import pathlib
+import uuid
 from contextlib import asynccontextmanager
 
 from jose import jwt
@@ -186,6 +189,41 @@ async def logout(request: Request):
 current_file_path = os.path.abspath(__file__)
 current_directory = os.path.dirname(current_file_path)
 nicegui.app.add_static_files('/images', f'{current_directory}/images')
+
+_UPLOADS_DIR = pathlib.Path(current_directory) / 'images' / 'uploads'
+_UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+
+_ALLOWED_IMAGE_TYPES = {'image/png', 'image/jpeg', 'image/gif', 'image/webp'}
+_ALLOWED_IMAGE_EXTS = {'.png', '.jpg', '.jpeg', '.gif', '.webp'}
+_MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+
+
+@nicegui.app.post('/api/upload-image')
+async def upload_image(request: Request, file: UploadFile = File(...)) -> JSONResponse:
+    if not User.current_user_is_admin(request=request):
+        return JSONResponse(status_code=403, content={'error': 'admin required'})
+
+    content_type = (file.content_type or '').lower()
+    if content_type not in _ALLOWED_IMAGE_TYPES:
+        return JSONResponse(status_code=400, content={'error': 'unsupported content type'})
+
+    ext = pathlib.Path(file.filename or '').suffix.lower()
+    if ext not in _ALLOWED_IMAGE_EXTS:
+        ext = {
+            'image/png': '.png',
+            'image/jpeg': '.jpg',
+            'image/gif': '.gif',
+            'image/webp': '.webp',
+        }[content_type]
+
+    data = await file.read(_MAX_UPLOAD_BYTES + 1)
+    if len(data) > _MAX_UPLOAD_BYTES:
+        return JSONResponse(status_code=413, content={'error': 'file too large'})
+
+    name = f'{uuid.uuid4().hex}{ext}'
+    (_UPLOADS_DIR / name).write_bytes(data)
+    return JSONResponse(status_code=200, content={'url': f'/images/uploads/{name}'})
+
 
 def assert_logged_in(request: Request):
     user = request.session.get("user")
@@ -382,10 +420,90 @@ def _render_event_form(event: Event | None, request: Request, session: Session) 
                 'Capacity (leave empty for unlimited)',
                 value=(str(event.capacity) if is_edit and event.capacity is not None else ''),
             ).props('type=number dense outlined').classes('w-full')
-        details_input = ui.textarea(
-            'Details (markdown supported)',
-            value=(event.details if is_edit else ''),
-        ).props('outlined').classes('w-full h-40 mt-2')
+        ui.add_head_html(
+            '<link rel="stylesheet" '
+            'href="https://uicdn.toast.com/editor/latest/toastui-editor.min.css" />'
+            '<script src="https://uicdn.toast.com/editor/latest/'
+            'toastui-editor-all.min.js"></script>'
+        )
+        initial_markdown = event.details if is_edit else ''
+
+        class _MarkdownHolder:
+            def __init__(self, value: str) -> None:
+                self.value = value
+
+        details_input = _MarkdownHolder(initial_markdown)
+        host_id = f'tui-editor-host-{id(details_input)}'
+        change_event = f'tui_md_change_{id(details_input)}'
+
+        def _on_md_change(e) -> None:
+            value = e.args
+            if isinstance(value, list) and value:
+                value = value[0]
+            details_input.value = value or ''
+
+        ui.on(change_event, _on_md_change)
+
+        ui.element('div').props(f'id={host_id}').classes('w-full mt-2')
+        ui.run_javascript(
+            f'''
+            (function() {{
+              const hostId = {json.dumps(host_id)};
+              const initialValue = {json.dumps(initial_markdown)};
+              const changeEvent = {json.dumps(change_event)};
+
+              function mountEditor() {{
+                const host = document.getElementById(hostId);
+                if (!host || !window.toastui || !window.toastui.Editor) {{
+                  return setTimeout(mountEditor, 50);
+                }}
+                if (host.dataset.tuiMounted === '1') return;
+                host.dataset.tuiMounted = '1';
+
+                const editor = new toastui.Editor({{
+                  el: host,
+                  height: '400px',
+                  initialEditType: 'wysiwyg',
+                  previewStyle: 'tab',
+                  initialValue: initialValue,
+                  usageStatistics: false,
+                  hooks: {{
+                    addImageBlobHook(blob, callback) {{
+                      const formData = new FormData();
+                      formData.append('file', blob, blob.name || 'pasted.png');
+                      fetch('/api/upload-image', {{
+                        method: 'POST',
+                        body: formData,
+                        credentials: 'same-origin',
+                      }})
+                        .then(async (r) => {{
+                          const text = await r.text();
+                          if (!r.ok) {{
+                            console.error('upload failed', r.status, text);
+                            throw new Error('HTTP ' + r.status + ': ' + text);
+                          }}
+                          return JSON.parse(text);
+                        }})
+                        .then(data => callback(data.url, 'image'))
+                        .catch((err) => {{
+                          console.error(err);
+                          alert('Image upload failed: ' + (err && err.message ? err.message : err));
+                        }});
+                    }},
+                  }},
+                  events: {{
+                    change: () => {{
+                      emitEvent(changeEvent, editor.getMarkdown());
+                    }},
+                  }},
+                }});
+                host._tuiEditor = editor;
+              }}
+
+              mountEditor();
+            }})();
+            '''
+        )
 
         def submit():
             # Re-bind actor for this handler task — the GET-time ContextVar

--- a/pack218/pages/home_page.py
+++ b/pack218/pages/home_page.py
@@ -247,7 +247,7 @@ def render_camping_trip_detail(event: Event, request: Request, session: SessionD
             )
 
         if (event.details or '').strip():
-            ui.markdown(event.details).classes('w-full')
+            ui.markdown(event.details, sanitize=False).classes('w-full')
 
         render_participants_table(event=event, request=request, session=session)
 


### PR DESCRIPTION
## Summary

- Replaces the plain markdown textarea on `/admin/events/new` and `/admin/events/{id}/edit` with the [Toast UI Editor](https://ui.toast.com/tui-editor) (WYSIWYG + Markdown source tab).
- Adds an admin-gated `POST /api/upload-image` endpoint that writes pasted/dropped images to `pack218/images/uploads/<uuid>.<ext>` and returns a URL the editor inserts as standard markdown: `![image](/images/uploads/<uuid>.<ext>)`.
- `event.details` remains a markdown string — no schema change. The render path (`ui.markdown(event.details)`) is unchanged except for `sanitize=False`, since the default browser Sanitizer strips `<img>`. Content is admin-curated, so this is safe.

## Implementation notes

- **Editor**: Toast UI is loaded from CDN via `ui.add_head_html`. The Python side holds a `_MarkdownHolder` whose `.value` mirrors what the editor reports. The editor's `change` event uses NiceGUI's `emitEvent` → `ui.on(...)` channel to push markdown back to Python without relying on DOM lookups.
- **Upload endpoint**: 403 for non-admins, content-type allowlist (`png|jpeg|gif|webp`), 10 MB cap, UUID filenames. Served from the existing `/images` static mount.
- **.gitignore**: `pack218/images/uploads/` so user-uploaded content doesn't get committed.

## Test plan

- [x] `/admin/events/new`: type formatted text → confirm WYSIWYG/Markdown tab toggle.
- [x] Paste an image from the clipboard → confirm `POST /api/upload-image` returns 200 with `{"url": ...}` and the markdown contains `![image](/images/uploads/<uuid>.png)`.
- [x] Save → reopen `/admin/events/<id>/edit` → markdown round-trips intact.
- [x] `/camping-trip/<id>` renders the formatted content and image inline.
- [ ] Logged-out `curl -X POST -F file=@x.png http://localhost:8001/api/upload-image` returns 403.
- [ ] Oversized image (>10 MB) returns 413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)